### PR TITLE
chore: close stale issue backlog + drop unused deps (#175)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,7 @@
                 "@fullcalendar/vue3": "^6.1",
                 "@headlessui/vue": "^1.7",
                 "@heroicons/vue": "^2.1",
-                "alpinejs": "^3.13",
-                "apexcharts": "^5.10",
-                "driver.js": "^1.4.0",
-                "vue3-apexcharts": "^1.5"
+                "driver.js": "^1.4.0"
             },
             "devDependencies": {
                 "@inertiajs/vue3": "^1.0",
@@ -1256,15 +1253,6 @@
             "integrity": "sha512-zSbjL7gRXwks2ZQLRGCajBtBXEOXW9Ddhn/HvSdrGkE2dqGnumzW8XtusRrxrE9LvqtiqDXQ+A60Hp6mvdYxfA==",
             "license": "MIT"
         },
-        "node_modules/@vue/reactivity": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.1.5.tgz",
-            "integrity": "sha512-1tdfLmNjWG6t/CsPldh+foumYFo3cpyCHgBYQ34ylaMsJ+SNHQ1kApMIa8jN+i593zQuaw3AdWH0nJTARzCFhg==",
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.1.5"
-            }
-        },
         "node_modules/@vue/runtime-core": {
             "version": "3.5.35",
             "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.35.tgz",
@@ -1336,12 +1324,6 @@
             "integrity": "sha512-zSbjL7gRXwks2ZQLRGCajBtBXEOXW9Ddhn/HvSdrGkE2dqGnumzW8XtusRrxrE9LvqtiqDXQ+A60Hp6mvdYxfA==",
             "license": "MIT"
         },
-        "node_modules/@vue/shared": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.1.5.tgz",
-            "integrity": "sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA==",
-            "license": "MIT"
-        },
         "node_modules/agent-base": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -1353,15 +1335,6 @@
             },
             "engines": {
                 "node": ">= 6.0.0"
-            }
-        },
-        "node_modules/alpinejs": {
-            "version": "3.15.12",
-            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.15.12.tgz",
-            "integrity": "sha512-nJvPAQVNPdZZ0NrExJ/kzQco3ijR8LwvCOadQecllESiqT4NyZ/57sN9V2XyvhlBGAbmlKYgeWZvYdKq99ij/Q==",
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "~3.1.1"
             }
         },
         "node_modules/any-promise": {
@@ -1384,12 +1357,6 @@
             "engines": {
                 "node": ">= 8"
             }
-        },
-        "node_modules/apexcharts": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-5.14.0.tgz",
-            "integrity": "sha512-hBLz5Gd8B5ZuocEzNUwEeKdw9vd7uy4OnqbDjAYyvwiAEyHk3OnO9+tGzAznpM6pnyCqWjPXUKKYoNIwdskeuQ==",
-            "license": "SEE LICENSE IN LICENSE"
         },
         "node_modules/arg": {
             "version": "5.0.2",
@@ -3269,21 +3236,6 @@
             "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.35.tgz",
             "integrity": "sha512-zSbjL7gRXwks2ZQLRGCajBtBXEOXW9Ddhn/HvSdrGkE2dqGnumzW8XtusRrxrE9LvqtiqDXQ+A60Hp6mvdYxfA==",
             "license": "MIT"
-        },
-        "node_modules/vue3-apexcharts": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/vue3-apexcharts/-/vue3-apexcharts-1.11.1.tgz",
-            "integrity": "sha512-MbN3vg8bMG19wc0Lm1HkeQvODgLm56DgpIxtNUO0xpf/JCzYWVGE4jzXp2JISzy2s3Kul1yOxNQUYsLvKQ5L9g==",
-            "license": "see LICENSE in LICENSE",
-            "peerDependencies": {
-                "apexcharts": ">=5.10.0",
-                "vue": ">=3.0.0"
-            },
-            "peerDependenciesMeta": {
-                "apexcharts": {
-                    "optional": false
-                }
-            }
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -30,9 +30,6 @@
         "@fullcalendar/vue3": "^6.1",
         "@headlessui/vue": "^1.7",
         "@heroicons/vue": "^2.1",
-        "alpinejs": "^3.13",
-        "apexcharts": "^5.10",
-        "driver.js": "^1.4.0",
-        "vue3-apexcharts": "^1.5"
+        "driver.js": "^1.4.0"
     }
 }


### PR DESCRIPTION
@
## Summary

Sweep of the open issue backlog (#166–#194). After syncing `main` (PR #198/#199 merged), every open issue except one was verified **already resolved** in current `main` — they were just never closed. This PR closes the one genuine remaining item and documents the evidence for the rest.

### Code change
- **#175** — removed unused `alpinejs`, `apexcharts`, `vue3-apexcharts` from `package.json`. Not imported anywhere in `resources/js`; production bundle is byte-for-byte identical after removal.

### Verified already-fixed on main (closing with evidence)
- **Health batch (#166–#174):** `php artisan test` → 274 passed; `npm run build` clean; `php artisan migrate:fresh --seed` clean. Covers build (#166), `currentTenant` (#167), duplicate migration (#168), tenant resolution via `SetCurrentTenant` (#169), API `role:admin|manager` pipe (#170), public inquiry (#171), venue required validation (#172), DemoDataSeeder (#173), test suite (#174).
- **Print/quotation batch (#182, #185–#190):** quotation PDF + in-browser print routes, status workflow (`transition()` + `TRANSITIONS`), inquiry→quotation prefill, `MANAGE_ROLES` gate (super_admin/tenant_owner) — green `QuotationPrintWorkflowTest`.
- **Super-admin platform (#191–#194):** `ImpersonationController`, `EnsureTenantActive` + suspend/activate, `AuditLogController`, `PlatformSettingsController` all present.

## Test plan
- [x] `php artisan test` — 274 passed, 5 pre-existing deprecations
- [x] `npm run build` — clean (bundle unchanged after dep removal)
- [x] `php artisan migrate:fresh --seed` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@