### PR TITLE
chore: gitignore seeded/uploaded avatars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,10 @@ storage/framework/views/*
 storage/logs/*
 !storage/logs/.gitkeep
 
+# User/seed-generated uploads (keep the dir, ignore its contents)
+storage/app/public/avatars/*
+!storage/app/public/avatars/.gitkeep
+
 # Compiled assets
 public/css
 public/js


### PR DESCRIPTION
Ignore storage/app/public/avatars contents (keep dir via .gitkeep) so seeded/uploaded avatars no longer show as untracked.