### PR TITLE
fix(auth): full-page visit on logout instead of Inertia error modal

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
+use Symfony\Component\HttpFoundation\Response as HttpResponse;
 
 class AuthenticatedSessionController extends Controller
 {
@@ -62,12 +63,16 @@ class AuthenticatedSessionController extends Controller
         return route('admin.dashboard');
     }
 
-    public function destroy(Request $request): RedirectResponse
+    public function destroy(Request $request): HttpResponse
     {
         Auth::guard('web')->logout();
         $request->session()->invalidate();
         $request->session()->regenerateToken();
 
-        return redirect('/');
+        // Logout is fired from the Inertia SPA, but '/' is a plain Blade page.
+        // Inertia::location() makes the client perform a real full-page visit
+        // (409 + X-Inertia-Location) instead of choking on the HTML response and
+        // rendering it inside its error modal. Plain requests get a normal 302.
+        return Inertia::location('/');
     }
 }

--- a/resources/js/Layouts/GuestLayout.vue
+++ b/resources/js/Layouts/GuestLayout.vue
@@ -7,10 +7,10 @@
         <div aria-hidden="true" class="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-[#c8a96a]/45 to-transparent"></div>
 
         <!-- Wordmark -->
-        <Link href="/" class="au-rise relative mb-8 inline-flex flex-col items-center gap-1" style="animation-delay:.05s">
+        <a href="/" class="au-rise relative mb-8 inline-flex flex-col items-center gap-1" style="animation-delay:.05s">
             <span class="font-display text-3xl font-light tracking-tight text-[#f5efe7]">EventPro</span>
             <span class="text-[0.62rem] uppercase tracking-[0.4em] text-[#c8a96a]">Events &amp; Celebrations</span>
-        </Link>
+        </a>
 
         <!-- Card -->
         <div class="au-rise relative w-full max-w-md rounded-2xl border border-black/5 bg-[#faf7f1] p-8 text-[#2b211b] shadow-2xl shadow-black/40 sm:p-10" style="animation-delay:.14s">
@@ -19,12 +19,8 @@
         </div>
 
         <!-- Back link -->
-        <Link href="/" class="au-rise relative mt-8 inline-flex items-center gap-2 text-xs text-[#80766a] transition-colors hover:text-[#cdbfae]" style="animation-delay:.22s">
+        <a href="/" class="au-rise relative mt-8 inline-flex items-center gap-2 text-xs text-[#80766a] transition-colors hover:text-[#cdbfae]" style="animation-delay:.22s">
             <span aria-hidden="true">&larr;</span> Back to site
-        </Link>
+        </a>
     </div>
 </template>
-
-<script setup>
-import { Link } from '@inertiajs/vue3';
-</script>

--- a/resources/js/Pages/Portal/Dashboard.vue
+++ b/resources/js/Pages/Portal/Dashboard.vue
@@ -91,7 +91,7 @@ function dismissNotification(id) {
                 <Link href="/portal/bookings" class="bg-surface border border-border rounded-lg p-4 text-center hover:shadow-md transition-shadow text-primary font-medium text-sm">My Bookings</Link>
                 <Link href="/portal/quotations" class="bg-surface border border-border rounded-lg p-4 text-center hover:shadow-md transition-shadow text-primary font-medium text-sm">Quotations</Link>
                 <Link href="/portal/payments" class="bg-surface border border-border rounded-lg p-4 text-center hover:shadow-md transition-shadow text-primary font-medium text-sm">Payments</Link>
-                <Link href="/venues" class="bg-surface border border-border rounded-lg p-4 text-center hover:shadow-md transition-shadow text-primary font-medium text-sm">Browse Venues</Link>
+                <a href="/venues" class="bg-surface border border-border rounded-lg p-4 text-center hover:shadow-md transition-shadow text-primary font-medium text-sm">Browse Venues</a>
             </div>
         </div>
     </PortalLayout>

--- a/tests/Feature/Auth/LogoutTest.php
+++ b/tests/Feature/Auth/LogoutTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Feature\Auth;
+
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Logout is always triggered from the Inertia SPA (router.post('/logout')). The
+ * landing page ('/') is a plain Blade page, NOT an Inertia page, so a plain 302
+ * redirect makes the Inertia client render the HTML response inside its error
+ * modal (a "floating window"). The controller must instead emit an
+ * Inertia-location response (409 + X-Inertia-Location) so the client performs a
+ * real full-page visit to the home page.
+ */
+class LogoutTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function user(): User
+    {
+        Tenant::factory()->create()->makeCurrent();
+
+        return User::factory()->create();
+    }
+
+    public function test_inertia_logout_returns_a_full_page_location_visit_to_home(): void
+    {
+        $user = $this->user();
+
+        $response = $this->actingAs($user)
+            ->withHeader('X-Inertia', 'true')
+            ->post('/logout');
+
+        // Inertia signals a full-page browser visit with 409 + X-Inertia-Location.
+        $response->assertStatus(409);
+        $response->assertHeader('X-Inertia-Location', '/');
+
+        $this->assertGuest();
+    }
+
+    public function test_plain_logout_still_redirects_to_home(): void
+    {
+        $user = $this->user();
+
+        $this->actingAs($user)
+            ->post('/logout')
+            ->assertRedirect('/');
+
+        $this->assertGuest();
+    }
+}


### PR DESCRIPTION
## Problem

Logging out opened a **floating window** over the app instead of redirecting to the home page.

That floating window is Inertia's **error modal**. The app is hybrid: admin + client portal are Inertia (Vue) SPAs, while the public site (`/`, `/venues`, …) is plain Blade. Inertia's `router.*`/`<Link>` issue XHRs expecting an Inertia response; when one lands on a Blade page, Inertia renders the raw HTML inside its modal.

Three places crossed this boundary incorrectly:

1. **Logout** — `AuthenticatedSessionController::destroy()` returned `redirect('/')` after an Inertia `router.post('/logout')` → modal *(reported bug)*.
2. **`GuestLayout.vue`** — login/register wordmark + "Back to site" `<Link href="/">`.
3. **`Portal/Dashboard.vue`** — "Browse Venues" `<Link href="/venues">`.

## Fix

- Logout now returns `Inertia::location('/')` — the SPA does a real full-page browser visit; plain HTTP requests still get a `302` to `/`. Return type widened to `Symfony\...\Response` (location() emits `409` for SPA requests).
- The two public-site links now use plain `<a>` tags (full-page navigation).
- New `LogoutTest` covers both the Inertia (`409` + `X-Inertia-Location`) and plain (`302`) responses.

Audited all 60+ `router`/`<Link>` call sites — these three were the only Inertia→Blade crossings.

## Verification

- `php artisan test` — **303 passed**, 1069 assertions, no regressions
- `php artisan test --filter=LogoutTest` — 2/2 pass
- `npm run build` — clean, no errors/warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)