### PR TITLE
fix(ui): PrimaryButton must submit its form (create quotation from inquiry)

### DIFF
--- a/resources/js/Components/PrimaryButton.vue
+++ b/resources/js/Components/PrimaryButton.vue
@@ -1,8 +1,14 @@
 <script setup>
 // Legacy shim — prefer importing Button from '@/Components/ui'.
+// Defaults to type="submit" (matching Breeze's PrimaryButton) so it submits the
+// surrounding form; ui/Button defaults to "button". Pass :type="'button'" for a
+// non-submit primary action.
 import Button from '@/Components/ui/Button.vue';
-defineProps({ disabled: Boolean });
+defineProps({
+    disabled: Boolean,
+    type: { type: String, default: 'submit' },
+});
 </script>
 <template>
-    <Button variant="primary" :disabled="disabled" v-bind="$attrs"><slot /></Button>
+    <Button variant="primary" :type="type" :disabled="disabled" v-bind="$attrs"><slot /></Button>
 </template>


### PR DESCRIPTION
## Problem

Creating a quotation from the **Inquiries** section did nothing — clicking "Create Quotation" never submitted, so no quotation was created or shown in the Quotations list.

## Root cause

`PrimaryButton` delegates to `ui/Button`, which defaults `type="button"`. `PrimaryButton` didn't pass a `type`, so every form that uses it as its action rendered a **non-submitting** button. Reproduced: clicking the submit button fired no POST and stayed on the create form.

This affected all `<PrimaryButton>` form actions: **Quotations, Bookings, Packages, Venues** (create + edit), plus Auth (register/forgot/reset) and Platform settings. (Forms using a raw `<button type="submit">` — Clients, Payments, Staff, Users, Vendors, Tenants — were unaffected.)

## Fix

Restore Laravel Breeze's contract: `PrimaryButton` now defaults to `type="submit"` (still overridable via `:type="'button'"`). One-file root fix covering all affected forms.

## Verification

Reproduced the inquiry → quotation flow in-browser:
- **Before:** click "Create Quotation" → no POST, stays on form, Quotations list stays at 4.
- **After:** `POST /admin/quotations` → **302**, redirects to `/admin/quotations`, list goes **4 → 5** — the new quotation appears.

No backend changes; `php artisan test` unaffected (307 passing on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)