### PR TITLE
fix(rbac): super_admin & tenant_owner blocked from admin mutations (booking confirm 403)

### DIFF
--- a/app/Http/Controllers/Admin/BookingController.php
+++ b/app/Http/Controllers/Admin/BookingController.php
@@ -57,7 +57,7 @@ class BookingController extends Controller
 
     public function store(Request $request, AvailabilityService $availability): RedirectResponse
     {
-        abort_unless($request->user()->hasAnyRole(['admin', 'manager']), 403);
+        abort_unless($request->user()->hasAnyRole(['super_admin', 'tenant_owner', 'admin', 'manager']), 403);
 
         $validated = $request->validate([
             'client_id' => ['required', TenantRule::exists('clients')],
@@ -108,7 +108,7 @@ class BookingController extends Controller
 
     public function update(Request $request, Booking $booking, AvailabilityService $availability): RedirectResponse
     {
-        abort_unless($request->user()->hasAnyRole(['admin', 'manager']), 403);
+        abort_unless($request->user()->hasAnyRole(['super_admin', 'tenant_owner', 'admin', 'manager']), 403);
 
         if (in_array($booking->status, ['completed', 'cancelled'], true)) {
             return back()->with('error', 'Completed or cancelled bookings cannot be edited.');
@@ -158,7 +158,7 @@ class BookingController extends Controller
 
     public function confirm(Booking $booking): RedirectResponse
     {
-        abort_unless(request()->user()->hasAnyRole(['admin', 'manager']), 403);
+        abort_unless(request()->user()->hasAnyRole(['super_admin', 'tenant_owner', 'admin', 'manager']), 403);
         if (! in_array($booking->status, ['pending', 'tentative'])) {
             return back()->with('error', 'Only pending or tentative bookings can be confirmed.');
         }
@@ -185,7 +185,7 @@ class BookingController extends Controller
 
     public function cancel(Request $request, Booking $booking): RedirectResponse
     {
-        abort_unless($request->user()->hasAnyRole(['admin', 'manager']), 403);
+        abort_unless($request->user()->hasAnyRole(['super_admin', 'tenant_owner', 'admin', 'manager']), 403);
         if (! $booking->canBeCancelled()) {
             return back()->with('error', 'This booking cannot be cancelled.');
         }
@@ -206,7 +206,7 @@ class BookingController extends Controller
 
     public function attachVendor(Request $request, Booking $booking): RedirectResponse
     {
-        abort_unless($request->user()->hasAnyRole(['admin', 'manager']), 403);
+        abort_unless($request->user()->hasAnyRole(['super_admin', 'tenant_owner', 'admin', 'manager']), 403);
         $data = $request->validate([
             'vendor_id' => ['required', TenantRule::exists('vendors')],
             'service_description' => 'nullable|string|max:500',
@@ -228,7 +228,7 @@ class BookingController extends Controller
 
     public function detachVendor(Booking $booking, Vendor $vendor): RedirectResponse
     {
-        abort_unless(request()->user()->hasAnyRole(['admin', 'manager']), 403);
+        abort_unless(request()->user()->hasAnyRole(['super_admin', 'tenant_owner', 'admin', 'manager']), 403);
         $booking->vendors()->detach($vendor->id);
 
         return back()->with('success', 'Vendor removed from booking.');

--- a/app/Http/Controllers/Admin/CustomFieldController.php
+++ b/app/Http/Controllers/Admin/CustomFieldController.php
@@ -31,7 +31,7 @@ class CustomFieldController extends Controller
 
     public function store(Request $request): RedirectResponse
     {
-        abort_unless($request->user()->hasAnyRole(['admin', 'manager']), 403);
+        abort_unless($request->user()->hasAnyRole(['super_admin', 'tenant_owner', 'admin', 'manager']), 403);
         $data = $request->validate([
             'entity_type' => 'required|in:booking,client,venue,inquiry,quotation',
             'name' => 'required|string|max:255',
@@ -55,7 +55,7 @@ class CustomFieldController extends Controller
 
     public function update(Request $request, CustomField $customField): RedirectResponse
     {
-        abort_unless($request->user()->hasAnyRole(['admin', 'manager']), 403);
+        abort_unless($request->user()->hasAnyRole(['super_admin', 'tenant_owner', 'admin', 'manager']), 403);
         $data = $request->validate([
             'name' => 'sometimes|string|max:255',
             'type' => 'sometimes|in:text,textarea,number,date,email,select,multiselect,checkbox,radio',
@@ -76,7 +76,7 @@ class CustomFieldController extends Controller
 
     public function destroy(CustomField $customField): RedirectResponse
     {
-        abort_unless(request()->user()->hasAnyRole(['admin', 'manager']), 403);
+        abort_unless(request()->user()->hasAnyRole(['super_admin', 'tenant_owner', 'admin', 'manager']), 403);
         $this->service->deleteField($customField);
 
         return back()->with('success', 'Custom field deleted.');

--- a/app/Http/Controllers/Admin/PackageController.php
+++ b/app/Http/Controllers/Admin/PackageController.php
@@ -44,7 +44,7 @@ class PackageController extends Controller
 
     public function store(Request $request): RedirectResponse
     {
-        abort_unless($request->user()->hasAnyRole(['admin', 'manager']), 403);
+        abort_unless($request->user()->hasAnyRole(['super_admin', 'tenant_owner', 'admin', 'manager']), 403);
         $validated = $request->validate([
             'name' => 'required|string|max:255',
             'slug' => 'nullable|string|max:255|unique:packages',
@@ -85,7 +85,7 @@ class PackageController extends Controller
 
     public function update(Request $request, Package $package): RedirectResponse
     {
-        abort_unless($request->user()->hasAnyRole(['admin', 'manager']), 403);
+        abort_unless($request->user()->hasAnyRole(['super_admin', 'tenant_owner', 'admin', 'manager']), 403);
         $validated = $request->validate([
             'name' => 'required|string|max:255',
             'slug' => 'nullable|string|max:255|unique:packages,slug,' . $package->id,
@@ -105,7 +105,7 @@ class PackageController extends Controller
 
     public function destroy(Package $package): RedirectResponse
     {
-        abort_unless(request()->user()->hasAnyRole(['admin', 'manager']), 403);
+        abort_unless(request()->user()->hasAnyRole(['super_admin', 'tenant_owner', 'admin', 'manager']), 403);
         if ($package->bookings()->whereNotIn('status', ['cancelled'])->exists()) {
             return back()->with('error', 'Cannot delete package with active bookings.');
         }

--- a/app/Http/Controllers/Admin/PluginController.php
+++ b/app/Http/Controllers/Admin/PluginController.php
@@ -23,7 +23,7 @@ class PluginController extends Controller
 
     public function enable(Request $request): RedirectResponse
     {
-        abort_unless($request->user()->hasRole('admin'), 403);
+        abort_unless($request->user()->hasAnyRole(['super_admin', 'tenant_owner', 'admin']), 403);
         $request->validate(['plugin' => 'required|string|max:100']);
         $success = $this->pluginService->enablePlugin($request->plugin);
 
@@ -32,7 +32,7 @@ class PluginController extends Controller
 
     public function disable(Request $request): RedirectResponse
     {
-        abort_unless($request->user()->hasRole('admin'), 403);
+        abort_unless($request->user()->hasAnyRole(['super_admin', 'tenant_owner', 'admin']), 403);
         $request->validate(['plugin' => 'required|string|max:100']);
         $this->pluginService->disablePlugin($request->plugin);
 

--- a/app/Http/Controllers/Admin/ThemeController.php
+++ b/app/Http/Controllers/Admin/ThemeController.php
@@ -23,7 +23,7 @@ class ThemeController extends Controller
 
     public function activate(Request $request): RedirectResponse
     {
-        abort_unless($request->user()->hasRole('admin'), 403);
+        abort_unless($request->user()->hasAnyRole(['super_admin', 'tenant_owner', 'admin']), 403);
         $request->validate(['theme' => 'required|string|max:100']);
 
         $success = $this->themeService->setActiveTheme($request->theme);

--- a/app/Http/Controllers/Admin/VendorController.php
+++ b/app/Http/Controllers/Admin/VendorController.php
@@ -43,7 +43,7 @@ class VendorController extends Controller
 
     public function store(Request $request): RedirectResponse
     {
-        abort_unless($request->user()->hasAnyRole(['admin', 'manager']), 403);
+        abort_unless($request->user()->hasAnyRole(['super_admin', 'tenant_owner', 'admin', 'manager']), 403);
         $data = $request->validate([
             'name' => 'required|string|max:255',
             'category' => 'required|string|max:50',
@@ -81,7 +81,7 @@ class VendorController extends Controller
 
     public function update(Request $request, Vendor $vendor): RedirectResponse
     {
-        abort_unless($request->user()->hasAnyRole(['admin', 'manager']), 403);
+        abort_unless($request->user()->hasAnyRole(['super_admin', 'tenant_owner', 'admin', 'manager']), 403);
         $data = $request->validate([
             'name' => 'required|string|max:255',
             'category' => 'required|string|max:50',
@@ -105,7 +105,7 @@ class VendorController extends Controller
 
     public function destroy(Vendor $vendor): RedirectResponse
     {
-        abort_unless(request()->user()->hasAnyRole(['admin', 'manager']), 403);
+        abort_unless(request()->user()->hasAnyRole(['super_admin', 'tenant_owner', 'admin', 'manager']), 403);
         if ($vendor->bookings()->whereNotIn('booking_vendor.status', ['cancelled'])->exists()) {
             return back()->with('error', 'Cannot delete vendor with active booking assignments.');
         }

--- a/tests/Feature/Admin/RbacEnforcementTest.php
+++ b/tests/Feature/Admin/RbacEnforcementTest.php
@@ -2,8 +2,11 @@
 
 namespace Tests\Feature\Admin;
 
+use App\Models\Booking;
+use App\Models\Client;
 use App\Models\Tenant;
 use App\Models\User;
+use App\Models\Venue;
 use Database\Seeders\RolePermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
@@ -108,5 +111,31 @@ class RbacEnforcementTest extends TestCase
 
         $this->post('/login', ['email' => $staff->email, 'password' => 'secret123'])
             ->assertRedirect(route('admin.dashboard'));
+    }
+
+    /**
+     * Booking mutations are gated by the bookings.* permission middleware, which
+     * super_admin and tenant_owner both hold — they must not be blocked by a
+     * narrower in-controller role check.
+     */
+    public function test_privileged_roles_can_confirm_a_tentative_booking(): void
+    {
+        $venue = Venue::factory()->create(['tenant_id' => $this->tenant->id]);
+        $client = Client::factory()->create(['tenant_id' => $this->tenant->id]);
+
+        foreach (['super_admin', 'tenant_owner', 'admin', 'manager'] as $role) {
+            $booking = Booking::factory()->create([
+                'tenant_id' => $this->tenant->id,
+                'venue_id' => $venue->id,
+                'client_id' => $client->id,
+                'status' => 'tentative',
+            ]);
+
+            $this->actingAs($this->user($role))
+                ->post("/admin/bookings/{$booking->id}/confirm")
+                ->assertRedirect();
+
+            $this->assertSame('confirmed', $booking->fresh()->status, "{$role} should be able to confirm a booking");
+        }
     }
 }


### PR DESCRIPTION
## Problem

Confirming a booking (`/admin/bookings/{id}` → "Confirm Booking") returned **403 Forbidden** for **super_admin** and **tenant_owner**.

## Root cause

Booking-mutation routes are already gated by the granular `permission:bookings.*` middleware, which super_admin (all permissions) and tenant_owner (all tenant permissions) both hold. But the controllers added a **redundant, narrower** check:

```php
abort_unless($request->user()->hasAnyRole(['admin', 'manager']), 403);
```

…which excludes super_admin and tenant_owner → 403 despite holding the permission.

## Similar issues fixed

Same anti-pattern across admin mutations:
- **Booking** (store/update/confirm/cancel/attach+detach vendor), **Vendor**, **Package**, **CustomField**: `['admin','manager']` → `['super_admin','tenant_owner','admin','manager']`.
- **Theme**/**Plugin** (activate/enable/disable): `hasRole('admin')` → `hasAnyRole(['super_admin','tenant_owner','admin'])`. These routes require `settings.edit`, which the `admin` role *lacks* — so the old check blocked **everyone** (admin failed the route, super_admin/tenant_owner failed the `hasRole('admin')` check). Theme/plugin activation was completely unusable.

## Verification

- New `RbacEnforcementTest::test_privileged_roles_can_confirm_a_tentative_booking` covers super_admin / tenant_owner / admin / manager (failed before, passes now).
- `php artisan test` → **308 passed**. PHPStan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)