### PR TITLE
feat(bookings): prefill the new booking form from an inquiry

### DIFF
--- a/app/Http/Controllers/Admin/BookingController.php
+++ b/app/Http/Controllers/Admin/BookingController.php
@@ -7,6 +7,7 @@ use App\Http\Resources\BookingResource;
 use App\Mail\BookingConfirmedMail;
 use App\Models\Booking;
 use App\Models\Client;
+use App\Models\Inquiry;
 use App\Models\Package;
 use App\Models\Tenant;
 use App\Models\Vendor;
@@ -43,8 +44,32 @@ class BookingController extends Controller
         ]);
     }
 
-    public function create(): Response
+    public function create(Request $request): Response
     {
+        // Prefill from an inquiry when converting (inquiry -> booking): carry every
+        // known detail forward so staff only fill the gaps (times, deposit, etc.).
+        $prefill = [];
+        if ($request->filled('inquiry_id')) {
+            $inquiry = Inquiry::find($request->integer('inquiry_id'));
+            if ($inquiry) {
+                $venue = $inquiry->venue_id ? Venue::find($inquiry->venue_id) : null;
+                $package = $inquiry->package_id ? Package::find($inquiry->package_id) : null;
+                $total = (float) ($venue->base_price ?? 0) + (float) ($package->base_price ?? 0);
+
+                $prefill = [
+                    'inquiry_id' => $inquiry->id,
+                    'client_id' => $inquiry->client_id,
+                    'venue_id' => $inquiry->venue_id,
+                    'package_id' => $inquiry->package_id,
+                    'event_type' => $inquiry->event_type,
+                    'event_date' => optional($inquiry->preferred_date)->toDateString(),
+                    'guest_count' => $inquiry->guest_count,
+                    'notes' => $inquiry->message,
+                    'total_amount' => $total > 0 ? $total : null,
+                ];
+            }
+        }
+
         return Inertia::render('Bookings/Create', [
             'venues' => Venue::where('status', 'active')->orderBy('name')->get(['id', 'name', 'base_price']),
             'packages' => Package::where('status', 'active')->orderBy('name')->get(['id', 'name', 'base_price']),
@@ -52,6 +77,7 @@ class BookingController extends Controller
                 'id' => $c->id,
                 'name' => trim("{$c->first_name} {$c->last_name}"),
             ]),
+            'prefill' => $prefill,
         ]);
     }
 

--- a/resources/js/Pages/Bookings/Create.vue
+++ b/resources/js/Pages/Bookings/Create.vue
@@ -10,24 +10,26 @@ const props = defineProps({
     venues: Array,
     packages: Array,
     clients: Array,
+    prefill: { type: Object, default: () => ({}) },
 });
 
 const params = new URLSearchParams(window.location.search);
+const pre = props.prefill ?? {};
 
 const form = useForm({
-    client_id: '',
-    venue_id: params.get('venue') ? Number(params.get('venue')) : '',
-    package_id: '',
-    event_type: 'wedding',
-    event_date: params.get('date') ?? '',
+    client_id: pre.client_id ?? '',
+    venue_id: pre.venue_id ?? (params.get('venue') ? Number(params.get('venue')) : ''),
+    package_id: pre.package_id ?? '',
+    event_type: pre.event_type ?? 'wedding',
+    event_date: pre.event_date ?? (params.get('date') ?? ''),
     setup_time: '',
     event_start_time: '',
     event_end_time: '',
-    guest_count: '',
-    total_amount: '',
+    guest_count: pre.guest_count ?? '',
+    total_amount: pre.total_amount ?? '',
     paid_amount: '',
     status: 'tentative',
-    notes: '',
+    notes: pre.notes ?? '',
 });
 
 const eventTypes = ['wedding', 'corporate', 'birthday', 'anniversary', 'conference', 'other'];
@@ -127,12 +129,12 @@ function submit() {
                         <InputError :message="form.errors.guest_count" class="mt-1" />
                     </div>
                     <div>
-                        <InputLabel for="total_amount" value="Total ($) *" />
+                        <InputLabel for="total_amount" value="Total (Rs) *" />
                         <TextInput id="total_amount" v-model="form.total_amount" type="number" min="0" step="0.01" class="mt-1 block w-full" required />
                         <InputError :message="form.errors.total_amount" class="mt-1" />
                     </div>
                     <div>
-                        <InputLabel for="paid_amount" value="Paid ($)" />
+                        <InputLabel for="paid_amount" value="Paid (Rs)" />
                         <TextInput id="paid_amount" v-model="form.paid_amount" type="number" min="0" step="0.01" class="mt-1 block w-full" />
                         <InputError :message="form.errors.paid_amount" class="mt-1" />
                     </div>

--- a/resources/js/Pages/Inquiries/Show.vue
+++ b/resources/js/Pages/Inquiries/Show.vue
@@ -162,7 +162,7 @@ const statusColors = {
                         <Link :href="`/admin/quotations/create?inquiry_id=${inquiry.id}`" class="block w-full text-center py-2 border border-primary text-primary text-sm font-medium rounded-lg hover:bg-primary/5">
                             Create Quotation
                         </Link>
-                        <Link href="/admin/bookings/create" class="block w-full text-center py-2 border border-border text-ink-muted text-sm font-medium rounded-lg hover:bg-surface-muted">
+                        <Link :href="`/admin/bookings/create?inquiry_id=${inquiry.id}`" class="block w-full text-center py-2 border border-border text-ink-muted text-sm font-medium rounded-lg hover:bg-surface-muted">
                             Create Booking
                         </Link>
                     </div>

--- a/tests/Feature/Admin/BookingPrefillTest.php
+++ b/tests/Feature/Admin/BookingPrefillTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\Client;
+use App\Models\Inquiry;
+use App\Models\Package;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Models\Venue;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Converting an inquiry into a booking carries every known detail forward, so
+ * staff only fill the gaps (times, deposit). The create form receives a prefill
+ * payload derived from the inquiry.
+ */
+class BookingPrefillTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $admin;
+
+    private Tenant $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->admin = User::factory()->admin()->create();
+        $this->tenant = $this->admin->tenant;
+    }
+
+    public function test_booking_create_prefills_from_inquiry(): void
+    {
+        $venue = Venue::factory()->create(['tenant_id' => $this->tenant->id, 'base_price' => 800000, 'status' => 'active']);
+        $package = Package::factory()->create(['tenant_id' => $this->tenant->id, 'base_price' => 200000, 'status' => 'active']);
+        $client = Client::factory()->create(['tenant_id' => $this->tenant->id]);
+
+        $inquiry = Inquiry::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'client_id' => $client->id,
+            'venue_id' => $venue->id,
+            'package_id' => $package->id,
+            'event_type' => 'wedding',
+            'preferred_date' => '2027-03-15',
+            'guest_count' => 220,
+            'message' => 'Looking for a grand wedding.',
+        ]);
+
+        $this->actingAs($this->admin)
+            ->get("/admin/bookings/create?inquiry_id={$inquiry->id}")
+            ->assertInertia(fn ($page) => $page
+                ->component('Bookings/Create')
+                ->where('prefill.client_id', $client->id)
+                ->where('prefill.venue_id', $venue->id)
+                ->where('prefill.package_id', $package->id)
+                ->where('prefill.event_type', 'wedding')
+                ->where('prefill.event_date', '2027-03-15')
+                ->where('prefill.guest_count', 220)
+                ->where('prefill.notes', 'Looking for a grand wedding.')
+                // venue base_price + package base_price (JSON-encoded as a number).
+                ->where('prefill.total_amount', 1000000));
+    }
+
+    public function test_booking_create_without_inquiry_has_empty_prefill(): void
+    {
+        $this->actingAs($this->admin)
+            ->get('/admin/bookings/create')
+            ->assertInertia(fn ($page) => $page
+                ->component('Bookings/Create')
+                ->where('prefill', []));
+    }
+}


### PR DESCRIPTION
## Summary

Creating a booking from an inquiry (`/admin/inquiries/{id}` → "Create Booking") now **carries every known detail forward**, so staff only fill the gaps.

Previously the link went to a blank `/admin/bookings/create` (no prefill), unlike the quotation flow which already prefilled.

## Changes

- **Inquiries/Show.vue** — "Create Booking" link now passes `?inquiry_id=…` (mirroring the existing Create Quotation link).
- **BookingController@create** — loads the inquiry and returns a `prefill`: `client_id`, `venue_id`, `package_id`, `event_type`, `event_date` (from `preferred_date`), `guest_count`, `notes` (the inquiry message), and a starting `total_amount` from the venue + package `base_price`.
- **Bookings/Create.vue** — initialises the form from `prefill` (falling back to the existing `?venue`/`?date` params). `Total`/`Paid` labels now read **Rs** instead of `$`.

No migration (bookings has no `inquiry_id` column; this prefills the form fields).

## Verification

- New `BookingPrefillTest`: the create form returns the inquiry-derived prefill (incl. `total_amount` = venue + package base price); empty inquiry → empty prefill.
- `php artisan test` → **310 passed**.
- Server-side check on seeded data: `GET /admin/bookings/create?inquiry_id=5` → 200 with full prefill (client/venue/package/anniversary/2027-03-12/40 guests/notes/total 5,250,000).

🤖 Generated with [Claude Code](https://claude.com/claude-code)