### PR TITLE
feat(inquiries): add Create Booking action to the inquiries list

### DIFF
--- a/resources/js/Pages/Inquiries/Index.vue
+++ b/resources/js/Pages/Inquiries/Index.vue
@@ -98,7 +98,10 @@ const statusColors = {
                                 </span>
                             </td>
                             <td class="px-6 py-4 text-right">
-                                <Link :href="`/admin/inquiries/${inquiry.id}`" class="text-primary hover:text-primary-dark text-sm font-medium">View</Link>
+                                <div class="flex items-center justify-end gap-3">
+                                    <Link :href="`/admin/inquiries/${inquiry.id}`" class="text-primary hover:text-primary-dark text-sm font-medium">View</Link>
+                                    <Link :href="`/admin/bookings/create?inquiry_id=${inquiry.id}`" class="text-ink-muted hover:text-ink text-sm font-medium">Create Booking</Link>
+                                </div>
                             </td>
                         </tr>
                         <tr v-if="!inquiries.data?.length">


### PR DESCRIPTION
## What
Adds a **Create Booking** link to each row on the inquiries list (`/admin/inquiries`), beside **View**. It points at `/admin/bookings/create?inquiry_id=<id>`.

## Why
Prefill from inquiry → booking already worked, but only from the inquiry **detail** page. Staff hitting the list had to open each inquiry first. This wires the same prefill straight from the list row.

## Behavior
Routes through the existing `BookingController@create` prefill — the new booking form arrives populated with the inquiry's client, venue, package, event type, date, guest count, notes and total. Staff fill only the gaps (times, deposit).

## Verification
Drove the real app (Playwright): list row → Create Booking → booking form rendered fully prefilled from the inquiry. Existing `BookingPrefillTest` covers the backend payload. `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)