### PR TITLE
docs: note PowerShell .\dev prefix for dev commands

### DIFF
--- a/DEMO-README.md
+++ b/DEMO-README.md
@@ -60,6 +60,15 @@ dev restore --all       :: restore every changed/missing file
 Artisan equivalents: `php artisan dev:baseline | dev:doctor | dev:restore`.
 Double-click wrappers: `tools\demo\{baseline,doctor,diff,restore}.cmd`.
 
+> **Shell note.** `dev doctor` works as-is in **cmd.exe**. In **PowerShell**, run it as
+> **`.\dev doctor`** (PowerShell won't run a program from the current folder without a path
+> prefix). The **`php artisan dev:doctor`** form works in *any* shell (PowerShell, cmd, bash)
+> and is the safest to use. To get a bare `dev` everywhere in PowerShell, add a function to
+> your `$PROFILE`:
+> ```powershell
+> function dev { & "C:\path\to\project\dev.cmd" @args }
+> ```
+
 ### The live-evaluation loop
 
 1. **Before** the evaluation, on healthy code: `dev baseline`.

--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ This repo ships a complete **offline + git-free** workflow — see [`DEMO-README
 - **`dev doctor`** — pinpoints exactly which files/lines were changed or deleted versus a
   captured baseline (no git needed), and runs every CRUD test. `dev baseline` captures the
   known-good state; `dev restore <path>` recovers from it. Works even if the app can't boot.
+  (In PowerShell run `.\dev doctor`; `php artisan dev:doctor` works in any shell.)
 - **`tools\demo\backup.cmd`** — zips the whole project (incl. `vendor/`, `node_modules/`) as
   a full safety net.
 

--- a/docs/EVALUATION_RECOVERY.md
+++ b/docs/EVALUATION_RECOVERY.md
@@ -43,6 +43,10 @@ tools\demo\backup.cmd
  3. dev doctor                 ->  confirm HEALTHY
 ```
 
+> **Shell note.** In **PowerShell** prefix with `.\` (`.\dev doctor`, `.\dev restore <path>`)
+> — PowerShell won't run a program from the current folder without it. In **cmd.exe** the bare
+> `dev doctor` works. `php artisan dev:doctor` / `dev:restore` work in any shell.
+
 What `dev doctor` shows:
 
 - **Source integrity vs baseline** — `DELETED` files, `MODIFIED` files with the

--- a/docs/OFFLINE_DEMO.md
+++ b/docs/OFFLINE_DEMO.md
@@ -125,7 +125,8 @@ To return to a clean, freshly-seeded database:
 ## 7. If something breaks during evaluation
 
 Run **`dev doctor`** — it finds exactly which files/lines changed or were deleted
-(git-free) and verifies every CRUD flow. See
+(git-free) and verifies every CRUD flow. (In PowerShell use `.\dev doctor`; in cmd.exe the
+bare `dev doctor` works; `php artisan dev:doctor` works in any shell.) See
 **[`docs/EVALUATION_RECOVERY.md`](EVALUATION_RECOVERY.md)** for the full playbook and
 the `tools\demo\` scripts (`baseline`, `doctor`, `diff`, `restore`, `backup`).
 

--- a/tools/demo/README.md
+++ b/tools/demo/README.md
@@ -18,6 +18,10 @@ dev run doctor      :: identical ("run" is optional)
 dev doctor --no-tests   :: fast - integrity + offline checks only, skips the test suite
 ```
 
+> **Shell note.** `dev doctor` works in **cmd.exe**. In **PowerShell** use **`.\dev doctor`**
+> (PowerShell won't run a program from the current folder without `.\`). `php artisan dev:doctor`
+> works in any shell.
+
 `dev doctor` reports three sections:
 
 1. **Source integrity vs baseline** — `DELETED`, `MODIFIED` (with the exact


### PR DESCRIPTION
`dev doctor` fails in PowerShell (`CommandNotFoundException`) because PowerShell won't run a program from the current directory without a `.\` prefix.

Document the fix across README, DEMO-README, and the demo/recovery docs:
- PowerShell: `.\dev doctor`
- cmd.exe: `dev doctor`
- any shell: `php artisan dev:doctor`

Plus a `$PROFILE` function snippet for a bare `dev` in PowerShell. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)