### PR TITLE
feat(pdf): A4-perfect, brand-coloured print/PDF documents

### DIFF
--- a/app/Http/Controllers/Admin/ReportController.php
+++ b/app/Http/Controllers/Admin/ReportController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Booking;
 use App\Models\Payment;
 use App\Models\Venue;
+use App\Services\BrandingService;
 use Barryvdh\DomPDF\Facade\Pdf;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
@@ -166,7 +167,7 @@ class ReportController extends Controller
 
     // ---- PDF exports ----------------------------------------------------
 
-    public function pdfRevenue(Request $request): SymfonyResponse
+    public function pdfRevenue(Request $request, BrandingService $branding): SymfonyResponse
     {
         [$start, $end, $meta] = $this->resolveRange($request);
         $data = $this->revenueData($start, $end);
@@ -176,10 +177,11 @@ class ReportController extends Controller
             'months' => $data['months'],
             'byMethod' => $data['byMethod'],
             'totals' => $data['totals'],
-        ])->download("revenue-{$meta['slug']}.pdf");
+            'branding' => $branding->getBranding(),
+        ])->setPaper('a4', 'portrait')->download("revenue-{$meta['slug']}.pdf");
     }
 
-    public function pdfBookings(Request $request): SymfonyResponse
+    public function pdfBookings(Request $request, BrandingService $branding): SymfonyResponse
     {
         [$start, $end, $meta] = $this->resolveRange($request);
         $data = $this->bookingsData($start, $end);
@@ -189,10 +191,11 @@ class ReportController extends Controller
             'months' => $data['months'],
             'byEventType' => $data['byEventType'],
             'totals' => $data['totals'],
-        ])->download("bookings-{$meta['slug']}.pdf");
+            'branding' => $branding->getBranding(),
+        ])->setPaper('a4', 'portrait')->download("bookings-{$meta['slug']}.pdf");
     }
 
-    public function pdfOccupancy(Request $request): SymfonyResponse
+    public function pdfOccupancy(Request $request, BrandingService $branding): SymfonyResponse
     {
         [$start, $end, $meta] = $this->resolveRange($request);
         $data = $this->occupancyData($start, $end);
@@ -200,7 +203,8 @@ class ReportController extends Controller
         return Pdf::loadView('pdf.reports.occupancy', [
             'period' => $meta['label'],
             'venueOccupancy' => $data['venueOccupancy'],
-        ])->download("occupancy-{$meta['slug']}.pdf");
+            'branding' => $branding->getBranding(),
+        ])->setPaper('a4', 'portrait')->download("occupancy-{$meta['slug']}.pdf");
     }
 
     // ---- Range resolution ----------------------------------------------

--- a/app/Services/BrandingService.php
+++ b/app/Services/BrandingService.php
@@ -28,6 +28,7 @@ class BrandingService
             'tagline' => $this->tenant->getSetting('general.tagline'),
             'logo' => $this->getLogoUrl(),
             'logo_dark' => $this->getLogoUrl('dark'),
+            'logo_pdf' => $this->getLogoDataUri(),
             'favicon' => $this->getFaviconUrl(),
             'colors' => [
                 'primary' => $this->tenant->primary_color ?? '#3B82F6',
@@ -109,6 +110,44 @@ CSS;
     }
 
     /**
+     * Resolve the tenant's uploaded logo to a base64 data URI for embedding in
+     * PDFs. dompdf cannot fetch remote http(s) URLs (and we keep remote fetching
+     * off for safety/offline), so the bytes are inlined directly.
+     *
+     * Returns null when the tenant has no custom logo — callers fall back to a
+     * styled business-name wordmark rather than stamping the generic app logo on
+     * a tenant's customer-facing handout.
+     */
+    private function getLogoDataUri(): ?string
+    {
+        $logo = $this->tenant?->getSetting('branding.logo') ?? $this->tenant?->logo;
+
+        if (! $logo || ! Storage::disk('public')->exists($logo)) {
+            return null;
+        }
+
+        $mime = match (strtolower(pathinfo($logo, PATHINFO_EXTENSION))) {
+            'png' => 'image/png',
+            'jpg', 'jpeg' => 'image/jpeg',
+            'gif' => 'image/gif',
+            'svg' => 'image/svg+xml',
+            default => null,
+        };
+
+        if ($mime === null) {
+            return null;
+        }
+
+        try {
+            $bytes = Storage::disk('public')->get($logo);
+        } catch (\Throwable $e) {
+            return null;
+        }
+
+        return 'data:'.$mime.';base64,'.base64_encode($bytes);
+    }
+
+    /**
      * Get default branding when no tenant.
      */
     private function getDefaultBranding(): array
@@ -118,6 +157,7 @@ CSS;
             'tagline' => 'Professional Event Management',
             'logo' => asset('images/logo.svg'),
             'logo_dark' => asset('images/logo.svg'),
+            'logo_pdf' => null,
             'favicon' => asset('images/favicon.svg'),
             'colors' => [
                 'primary' => '#3B82F6',

--- a/resources/views/pdf/inquiry.blade.php
+++ b/resources/views/pdf/inquiry.blade.php
@@ -3,140 +3,103 @@
 <head>
     <meta charset="UTF-8">
     <title>Inquiry {{ $inquiry->inquiry_number }}</title>
-    <style>
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-        body { font-family: 'DejaVu Sans', Arial, sans-serif; font-size: 13px; color: #1f2937; line-height: 1.5; }
-        .page { padding: 40px; max-width: 800px; margin: 0 auto; }
-
-        .header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 36px; padding-bottom: 24px; border-bottom: 3px solid #4f46e5; }
-        .company-name { font-size: 22px; font-weight: 700; color: #4f46e5; }
-        .company-sub { font-size: 12px; color: #6b7280; margin-top: 2px; }
-        .doc-title { text-align: right; }
-        .doc-title h1 { font-size: 28px; font-weight: 700; color: #111827; letter-spacing: -0.5px; }
-        .doc-title .doc-number { font-size: 14px; color: #4f46e5; font-weight: 600; margin-top: 4px; }
-        .doc-title .doc-date { font-size: 12px; color: #6b7280; }
-
-        .status-badge { display: inline-block; padding: 3px 10px; border-radius: 20px; font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; background: #fef3c7; color: #92400e; }
-
-        .two-col { display: flex; gap: 40px; margin-bottom: 32px; }
-        .col { flex: 1; }
-        .section-label { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; color: #9ca3af; margin-bottom: 6px; }
-        .section-value { font-size: 14px; font-weight: 600; color: #111827; }
-        .section-sub { font-size: 12px; color: #4b5563; margin-top: 2px; }
-
-        .event-box { background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 8px; padding: 16px 20px; margin-bottom: 28px; }
-        .event-box-title { font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.8px; color: #6b7280; margin-bottom: 12px; }
-        .event-grid { display: flex; gap: 28px; flex-wrap: wrap; }
-        .event-item { margin-bottom: 8px; }
-        .event-item label { font-size: 11px; color: #9ca3af; display: block; }
-        .event-item span { font-size: 13px; font-weight: 600; color: #374151; }
-
-        .message-box { margin-top: 8px; padding: 16px 20px; background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 8px; }
-        .message-box h3 { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.8px; color: #9ca3af; margin-bottom: 8px; }
-        .message-box p { font-size: 12px; color: #4b5563; line-height: 1.6; }
-
-        .footer { margin-top: 32px; padding-top: 16px; border-top: 1px solid #e5e7eb; text-align: center; font-size: 11px; color: #9ca3af; }
-    </style>
+    @include('pdf.partials.styles', [
+        'primary' => $branding['colors']['primary'] ?? '#4f46e5',
+        'accent' => $branding['colors']['accent'] ?? '#10b981',
+    ])
 </head>
 <body>
+@include('pdf.partials.footer', ['branding' => $branding, 'note' => 'Inquiry '.$inquiry->inquiry_number])
 <div class="page">
 
-    <div class="header">
-        <div>
-            <div class="company-name">{{ $branding['business_name'] ?? config('app.name') }}</div>
-            @if(!empty($branding['address']))
-                <div class="company-sub">{{ $branding['address'] }}</div>
-            @endif
-            @if(!empty($branding['phone']))
-                <div class="company-sub">{{ $branding['phone'] }}</div>
-            @endif
-        </div>
-        <div class="doc-title">
-            <h1>INQUIRY</h1>
-            <div class="doc-number">{{ $inquiry->inquiry_number }}</div>
-            <div class="doc-date">Received: {{ $inquiry->created_at->format('d M Y') }}</div>
-            <div style="margin-top:6px">
-                <span class="status-badge">{{ ucfirst(str_replace('_', ' ', $inquiry->status)) }}</span>
-            </div>
-        </div>
-    </div>
+    @include('pdf.partials.header', [
+        'branding' => $branding,
+        'docType' => 'INQUIRY',
+        'docNumber' => $inquiry->inquiry_number,
+        'docDateLabel' => 'Received',
+        'docDate' => $inquiry->created_at->format('d M Y'),
+        'statusClass' => 'neutral',
+        'statusText' => ucfirst(str_replace('_', ' ', $inquiry->status)),
+    ])
 
-    <div class="two-col">
-        <div class="col">
-            <div class="section-label">Client</div>
-            @if($inquiry->client)
-                <div class="section-value">{{ $inquiry->client->full_name }}</div>
-                <div class="section-sub">{{ $inquiry->client->email }}</div>
-                @if($inquiry->client->phone)
-                    <div class="section-sub">{{ $inquiry->client->phone }}</div>
+    <table class="info-table">
+        <tr>
+            <td style="width:40%">
+                <div class="section-label">Client</div>
+                @if($inquiry->client)
+                    <div class="section-value">{{ $inquiry->client->full_name }}</div>
+                    <div class="section-sub">{{ $inquiry->client->email }}</div>
+                    @if($inquiry->client->phone)
+                        <div class="section-sub">{{ $inquiry->client->phone }}</div>
+                    @endif
+                @else
+                    <div class="section-value">&mdash;</div>
                 @endif
-            @else
-                <div class="section-value">&mdash;</div>
-            @endif
-        </div>
-        <div class="col">
-            <div class="section-label">Venue Interest</div>
-            <div class="section-value">{{ $inquiry->venue?->name ?? '—' }}</div>
-        </div>
-        <div class="col">
-            <div class="section-label">Source</div>
-            <div class="section-value">{{ ucfirst(str_replace('_', ' ', $inquiry->source ?? 'website')) }}</div>
-        </div>
-    </div>
+            </td>
+            <td style="width:35%">
+                <div class="section-label">Venue Interest</div>
+                <div class="section-value">{{ $inquiry->venue?->name ?? '—' }}</div>
+            </td>
+            <td style="width:25%">
+                <div class="section-label">Source</div>
+                <div class="section-value">{{ ucfirst(str_replace('_', ' ', $inquiry->source ?? 'website')) }}</div>
+            </td>
+        </tr>
+    </table>
 
-    <div class="event-box">
-        <div class="event-box-title">Event Details</div>
-        <div class="event-grid">
-            <div class="event-item">
-                <label>Event Type</label>
-                <span>{{ ucfirst(str_replace('_', ' ', $inquiry->event_type ?? '—')) }}</span>
-            </div>
-            <div class="event-item">
-                <label>Preferred Date</label>
-                <span>{{ $inquiry->preferred_date?->format('l, d F Y') ?? '—' }}</span>
-            </div>
-            @if($inquiry->alternate_date)
-                <div class="event-item">
-                    <label>Alternate Date</label>
-                    <span>{{ $inquiry->alternate_date->format('d F Y') }}</span>
-                </div>
-            @endif
-            <div class="event-item">
-                <label>Guest Count</label>
-                <span>{{ $inquiry->guest_count ? number_format($inquiry->guest_count).' guests' : '—' }}</span>
-            </div>
-            @if($inquiry->budget_range_min || $inquiry->budget_range_max)
-                <div class="event-item">
-                    <label>Budget Range</label>
-                    <span>{{ number_format($inquiry->budget_range_min ?? 0, 2) }} &ndash; {{ number_format($inquiry->budget_range_max ?? 0, 2) }}</span>
-                </div>
-            @endif
-            @if($inquiry->package)
-                <div class="event-item">
-                    <label>Package</label>
-                    <span>{{ $inquiry->package->name }}</span>
-                </div>
-            @endif
-        </div>
+    <div class="detail-box">
+        <div class="detail-box-title">Event Details</div>
+        <table class="detail-grid">
+            <tr>
+                <td style="width:34%">
+                    <label>Event Type</label>
+                    <span>{{ ucfirst(str_replace('_', ' ', $inquiry->event_type ?? '—')) }}</span>
+                </td>
+                <td style="width:33%">
+                    <label>Preferred Date</label>
+                    <span>{{ $inquiry->preferred_date?->format('l, d F Y') ?? '—' }}</span>
+                </td>
+                <td style="width:33%">
+                    <label>Guest Count</label>
+                    <span>{{ $inquiry->guest_count ? number_format($inquiry->guest_count).' guests' : '—' }}</span>
+                </td>
+            </tr>
+            <tr>
+                @if($inquiry->alternate_date)
+                    <td>
+                        <label>Alternate Date</label>
+                        <span>{{ $inquiry->alternate_date->format('d F Y') }}</span>
+                    </td>
+                @endif
+                @if($inquiry->budget_range_min || $inquiry->budget_range_max)
+                    <td>
+                        <label>Budget Range</label>
+                        <span>{{ number_format($inquiry->budget_range_min ?? 0, 2) }} &ndash; {{ number_format($inquiry->budget_range_max ?? 0, 2) }}</span>
+                    </td>
+                @endif
+                @if($inquiry->package)
+                    <td>
+                        <label>Package</label>
+                        <span>{{ $inquiry->package->name }}</span>
+                    </td>
+                @endif
+            </tr>
+        </table>
     </div>
 
     @if($inquiry->message)
-        <div class="message-box">
+        <div class="panel">
             <h3>Message</h3>
             <p>{{ $inquiry->message }}</p>
         </div>
     @endif
 
     @if($inquiry->notes)
-        <div class="message-box" style="margin-top:16px">
+        <div class="panel">
             <h3>Internal Notes</h3>
             <p>{{ $inquiry->notes }}</p>
         </div>
     @endif
-
-    <div class="footer">
-        {{ $branding['business_name'] ?? config('app.name') }} &middot; Inquiry {{ $inquiry->inquiry_number }}
-    </div>
 </div>
 @if(!empty($print))
     <script>window.addEventListener('load', function () { window.print(); });</script>

--- a/resources/views/pdf/partials/footer.blade.php
+++ b/resources/views/pdf/partials/footer.blade.php
@@ -1,0 +1,5 @@
+{{-- Fixed footer rendered on every page. Expects: $branding, $note (optional) --}}
+<div class="doc-footer">
+    <div class="thanks">{{ $branding['business_name'] ?? config('app.name') }}</div>
+    <div>{{ $note ?? 'Thank you for your business.' }} &middot; Generated {{ now()->format('d M Y') }}</div>
+</div>

--- a/resources/views/pdf/partials/header.blade.php
+++ b/resources/views/pdf/partials/header.blade.php
@@ -1,0 +1,39 @@
+{{-- Brand header band. Expects:
+     $branding, $docType, $docNumber (nullable), $docDateLabel, $docDate,
+     $statusClass (nullable), $statusText (nullable) --}}
+@php
+    $contact = $branding['contact'] ?? [];
+    $contactLine = collect([$contact['address'] ?? null, $contact['city'] ?? null, $contact['country'] ?? null])
+        ->filter()->implode(', ');
+@endphp
+<div class="brand-band">
+    <table>
+        <tr>
+            <td style="width:60%">
+                @if(!empty($branding['logo_pdf']))
+                    <img src="{{ $branding['logo_pdf'] }}" class="brand-logo" alt="">
+                @endif
+                <div class="brand-name">{{ $branding['business_name'] ?? config('app.name') }}</div>
+                @if(!empty($branding['tagline']))
+                    <div class="brand-tagline">{{ $branding['tagline'] }}</div>
+                @endif
+                <div class="brand-contact">
+                    @if($contactLine){{ $contactLine }}<br>@endif
+                    @if(!empty($contact['phone'])){{ $contact['phone'] }}@endif
+                    @if(!empty($contact['phone']) && !empty($contact['email'])) &middot; @endif
+                    @if(!empty($contact['email'])){{ $contact['email'] }}@endif
+                </div>
+            </td>
+            <td class="doc-meta" style="width:40%">
+                <div class="doc-type">{{ $docType }}</div>
+                @if(!empty($docNumber))
+                    <div class="doc-number">{{ $docNumber }}</div>
+                @endif
+                <div class="doc-date">{{ $docDateLabel }} {{ $docDate }}</div>
+                @if(!empty($statusText))
+                    <span class="status-badge status-{{ $statusClass ?? 'neutral' }}">{{ $statusText }}</span>
+                @endif
+            </td>
+        </tr>
+    </table>
+</div>

--- a/resources/views/pdf/partials/styles.blade.php
+++ b/resources/views/pdf/partials/styles.blade.php
@@ -1,0 +1,118 @@
+{{-- Shared, dompdf-safe stylesheet for customer-facing documents (quotation,
+     inquiry, receipt). dompdf has NO flexbox/grid support, so every multi-column
+     layout here is built with tables or inline-block. Brand colours are injected
+     from BrandingService (already sanitised to a CSS-colour shape).
+     Expects: $primary, $accent --}}
+@php
+    $primary = $primary ?? '#4f46e5';
+    $accent  = $accent  ?? '#10b981';
+@endphp
+<style>
+    @page { margin: 0; }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body { width: 100%; }
+    body {
+        font-family: 'DejaVu Sans', Arial, sans-serif;
+        font-size: 12.5px;
+        color: #1f2937;
+        line-height: 1.5;
+    }
+    .page { padding: 30px 40px 70px; }
+
+    /* ---- Header band -------------------------------------------------- */
+    .brand-band {
+        width: 100%;
+        background: {{ $primary }};
+        border-radius: 10px;
+        color: #ffffff;
+        margin-bottom: 20px;
+    }
+    .brand-band table { width: 100%; border-collapse: collapse; }
+    .brand-band td { padding: 16px 22px; vertical-align: middle; }
+    .brand-logo { height: 38px; margin-bottom: 6px; }
+    .brand-name { font-size: 21px; font-weight: 700; color: #ffffff; letter-spacing: -0.2px; }
+    .brand-tagline { font-size: 11px; color: rgba(255,255,255,0.82); margin-top: 2px; }
+    .brand-contact { font-size: 10.5px; color: rgba(255,255,255,0.82); margin-top: 6px; line-height: 1.45; }
+    .doc-meta { text-align: right; }
+    .doc-meta .doc-type { font-size: 26px; font-weight: 700; color: #ffffff; letter-spacing: 1px; }
+    .doc-meta .doc-number { font-size: 13px; color: #ffffff; font-weight: 600; margin-top: 4px; }
+    .doc-meta .doc-date { font-size: 11px; color: rgba(255,255,255,0.82); margin-top: 2px; }
+
+    /* ---- Status badge ------------------------------------------------- */
+    .status-badge { display: inline-block; padding: 3px 11px; border-radius: 20px; font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.6px; margin-top: 8px; }
+    .status-draft, .status-pending { background: #fef3c7; color: #92400e; }
+    .status-sent { background: #dbeafe; color: #1e40af; }
+    .status-viewed { background: #e0e7ff; color: #3730a3; }
+    .status-accepted, .status-completed { background: #d1fae5; color: #065f46; }
+    .status-expired, .status-failed { background: #fee2e2; color: #991b1b; }
+    .status-refunded { background: #e0e7ff; color: #3730a3; }
+    .status-neutral { background: #f1f5f9; color: #475569; }
+
+    /* ---- Info columns (table, not flex) ------------------------------- */
+    .info-table { width: 100%; border-collapse: collapse; margin-bottom: 18px; }
+    .info-table td { vertical-align: top; padding-right: 24px; }
+    .info-table td:last-child { padding-right: 0; }
+    .section-label { font-size: 9.5px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; color: #9ca3af; margin-bottom: 5px; }
+    .section-value { font-size: 13.5px; font-weight: 600; color: #111827; }
+    .section-sub { font-size: 11.5px; color: #4b5563; margin-top: 2px; }
+
+    /* ---- Boxed detail block ------------------------------------------- */
+    .detail-box { background: #f9fafb; border: 1px solid #e9ebef; border-left: 4px solid {{ $primary }}; border-radius: 8px; padding: 14px 18px; margin-bottom: 18px; }
+    .detail-box-title { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.8px; color: {{ $primary }}; margin-bottom: 12px; }
+    .detail-grid { width: 100%; border-collapse: collapse; }
+    .detail-grid td { vertical-align: top; padding: 0 18px 8px 0; }
+    .detail-grid label { font-size: 10px; color: #9ca3af; display: block; }
+    .detail-grid span { font-size: 12.5px; font-weight: 600; color: #374151; }
+
+    /* ---- Line items table --------------------------------------------- */
+    table.items { width: 100%; border-collapse: collapse; margin-bottom: 18px; }
+    table.items thead { display: table-header-group; }
+    table.items thead th { background: {{ $primary }}; color: #ffffff; padding: 8px 12px; text-align: left; font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.5px; }
+    table.items thead th.num { text-align: right; }
+    table.items tbody tr { page-break-inside: avoid; }
+    table.items tbody td { padding: 6px 12px; border-bottom: 1px solid #eef0f3; font-size: 12.5px; }
+    table.items tbody td.num { text-align: right; font-variant-numeric: tabular-nums; }
+    table.items tbody tr:nth-child(even) td { background: #f9fafb; }
+    table.items .item-sub { font-size: 10.5px; color: #6b7280; margin-top: 2px; }
+
+    /* ---- Totals (table, not flex) ------------------------------------- */
+    .totals { width: 270px; margin-left: auto; margin-bottom: 16px; }
+    .totals table { width: 100%; border-collapse: collapse; }
+    .totals td { padding: 5px 0; font-size: 12.5px; }
+    .totals td.label { color: #6b7280; }
+    .totals td.value { text-align: right; font-weight: 600; color: #111827; }
+    .totals tr.subtotal td { border-top: 1px solid #e5e7eb; padding-top: 8px; }
+    .totals tr.discount td.value { color: #059669; }
+    .totals tr.total td { border-top: 2px solid {{ $primary }}; padding-top: 9px; font-size: 16px; font-weight: 700; color: {{ $primary }}; }
+
+    /* ---- Callouts ----------------------------------------------------- */
+    .callout { border-radius: 8px; padding: 11px 16px; margin-bottom: 14px; }
+    .callout.amount { background: #f9fafb; border: 1px solid #e9ebef; text-align: center; padding: 20px 24px; }
+    .callout.amount .label { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; color: #6b7280; }
+    .callout.amount .value { font-size: 30px; font-weight: 700; color: {{ $primary }}; margin-top: 4px; }
+    .callout.note { background: #fffbeb; border-left: 4px solid #f59e0b; }
+    .callout.note .t { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.8px; color: #92400e; margin-bottom: 4px; }
+    .callout.note p { font-size: 11.5px; color: #78350f; }
+    .callout.info { background: #eff6ff; border: 1px solid #bfdbfe; text-align: center; font-size: 11.5px; color: #1e40af; }
+
+    .panel { background: #f9fafb; border: 1px solid #e9ebef; border-radius: 8px; padding: 16px 20px; margin-bottom: 16px; }
+    .panel h3 { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.8px; color: #9ca3af; margin-bottom: 8px; }
+    .panel p { font-size: 11.5px; color: #4b5563; line-height: 1.6; }
+
+    .terms { margin-top: 14px; padding-top: 14px; border-top: 1px solid #e5e7eb; }
+    .terms h3 { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.8px; color: #9ca3af; margin-bottom: 8px; }
+    .terms p { font-size: 10.5px; color: #6b7280; line-height: 1.6; }
+
+    /* ---- Fixed footer on every page ----------------------------------- */
+    .doc-footer {
+        position: fixed;
+        bottom: 0; left: 0; right: 0;
+        height: 50px;
+        padding: 12px 40px 0;
+        border-top: 2px solid {{ $accent }};
+        text-align: center;
+        font-size: 10px;
+        color: #9ca3af;
+    }
+    .doc-footer .thanks { color: {{ $primary }}; font-weight: 700; font-size: 11px; }
+</style>

--- a/resources/views/pdf/quotation.blade.php
+++ b/resources/views/pdf/quotation.blade.php
@@ -2,159 +2,93 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Quotation {{ $quotation->quotation_number }}</title>
-    <style>
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-        body { font-family: 'DejaVu Sans', Arial, sans-serif; font-size: 13px; color: #1f2937; line-height: 1.5; }
-        .page { padding: 40px; max-width: 800px; margin: 0 auto; }
-
-        /* Header */
-        .header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 36px; padding-bottom: 24px; border-bottom: 3px solid #4f46e5; }
-        .company-name { font-size: 22px; font-weight: 700; color: #4f46e5; }
-        .company-sub { font-size: 12px; color: #6b7280; margin-top: 2px; }
-        .doc-title { text-align: right; }
-        .doc-title h1 { font-size: 28px; font-weight: 700; color: #111827; letter-spacing: -0.5px; }
-        .doc-title .doc-number { font-size: 14px; color: #4f46e5; font-weight: 600; margin-top: 4px; }
-        .doc-title .doc-date { font-size: 12px; color: #6b7280; }
-
-        /* Status badge */
-        .status-badge { display: inline-block; padding: 3px 10px; border-radius: 20px; font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
-        .status-draft { background: #fef3c7; color: #92400e; }
-        .status-sent { background: #dbeafe; color: #1e40af; }
-        .status-viewed { background: #e0e7ff; color: #3730a3; }
-        .status-accepted { background: #d1fae5; color: #065f46; }
-        .status-expired { background: #fee2e2; color: #991b1b; }
-
-        /* Two-column section */
-        .two-col { display: flex; gap: 40px; margin-bottom: 32px; }
-        .col { flex: 1; }
-        .section-label { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; color: #9ca3af; margin-bottom: 6px; }
-        .section-value { font-size: 14px; font-weight: 600; color: #111827; }
-        .section-sub { font-size: 12px; color: #4b5563; margin-top: 2px; }
-
-        /* Event details */
-        .event-box { background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 8px; padding: 16px 20px; margin-bottom: 28px; }
-        .event-box-title { font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.8px; color: #6b7280; margin-bottom: 12px; }
-        .event-grid { display: flex; gap: 20px; flex-wrap: wrap; }
-        .event-item label { font-size: 11px; color: #9ca3af; display: block; }
-        .event-item span { font-size: 13px; font-weight: 600; color: #374151; }
-
-        /* Items table */
-        table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-        thead th { background: #4f46e5; color: white; padding: 10px 12px; text-align: left; font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
-        thead th:last-child { text-align: right; }
-        tbody td { padding: 10px 12px; border-bottom: 1px solid #f3f4f6; font-size: 13px; }
-        tbody td:last-child { text-align: right; font-weight: 500; }
-        tbody tr:last-child td { border-bottom: none; }
-        tbody tr:nth-child(even) { background: #f9fafb; }
-
-        /* Totals */
-        .totals { margin-left: auto; width: 260px; margin-bottom: 28px; }
-        .totals-row { display: flex; justify-content: space-between; padding: 6px 0; font-size: 13px; }
-        .totals-row.subtotal { border-top: 1px solid #e5e7eb; }
-        .totals-row.discount { color: #059669; }
-        .totals-row.tax { color: #6b7280; }
-        .totals-row.total { border-top: 2px solid #4f46e5; padding-top: 10px; font-size: 16px; font-weight: 700; color: #4f46e5; }
-        .totals-label { color: #6b7280; }
-
-        /* Validity */
-        .validity { text-align: center; background: #eff6ff; border: 1px solid #bfdbfe; border-radius: 6px; padding: 10px; margin-bottom: 24px; font-size: 12px; color: #1e40af; }
-
-        /* Terms */
-        .terms { margin-top: 24px; padding-top: 18px; border-top: 1px solid #e5e7eb; }
-        .terms h3 { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.8px; color: #9ca3af; margin-bottom: 8px; }
-        .terms p { font-size: 11px; color: #6b7280; line-height: 1.6; }
-
-        /* Footer */
-        .footer { margin-top: 32px; padding-top: 16px; border-top: 1px solid #e5e7eb; text-align: center; font-size: 11px; color: #9ca3af; }
-    </style>
+    @include('pdf.partials.styles', [
+        'primary' => $branding['colors']['primary'] ?? '#4f46e5',
+        'accent' => $branding['colors']['accent'] ?? '#10b981',
+    ])
 </head>
 <body>
+@include('pdf.partials.footer', ['branding' => $branding, 'note' => 'Quotation '.$quotation->quotation_number])
 <div class="page">
 
-    <!-- Header -->
-    <div class="header">
-        <div>
-            <div class="company-name">{{ $branding['business_name'] ?? config('app.name') }}</div>
-            @if(!empty($branding['address']))
-                <div class="company-sub">{{ $branding['address'] }}</div>
-            @endif
-            @if(!empty($branding['phone']))
-                <div class="company-sub">{{ $branding['phone'] }}</div>
-            @endif
-        </div>
-        <div class="doc-title">
-            <h1>QUOTATION</h1>
-            <div class="doc-number">{{ $quotation->quotation_number }}</div>
-            <div class="doc-date">Issued: {{ $quotation->created_at->format('d M Y') }}</div>
-            <div style="margin-top:6px">
-                <span class="status-badge status-{{ $quotation->status }}">{{ ucfirst($quotation->status) }}</span>
-            </div>
-        </div>
-    </div>
+    @include('pdf.partials.header', [
+        'branding' => $branding,
+        'docType' => 'QUOTATION',
+        'docNumber' => $quotation->quotation_number,
+        'docDateLabel' => 'Issued',
+        'docDate' => $quotation->created_at->format('d M Y'),
+        'statusClass' => $quotation->status,
+        'statusText' => ucfirst($quotation->status),
+    ])
 
-    <!-- Client & Venue -->
-    <div class="two-col">
-        <div class="col">
-            <div class="section-label">Prepared For</div>
-            @if($quotation->client)
-                <div class="section-value">{{ $quotation->client->full_name }}</div>
-                <div class="section-sub">{{ $quotation->client->email }}</div>
-                @if($quotation->client->phone)
-                    <div class="section-sub">{{ $quotation->client->phone }}</div>
+    {{-- Client / Venue / Validity --}}
+    <table class="info-table">
+        <tr>
+            <td style="width:40%">
+                <div class="section-label">Prepared For</div>
+                @if($quotation->client)
+                    <div class="section-value">{{ $quotation->client->full_name }}</div>
+                    <div class="section-sub">{{ $quotation->client->email }}</div>
+                    @if($quotation->client->phone)
+                        <div class="section-sub">{{ $quotation->client->phone }}</div>
+                    @endif
+                @else
+                    <div class="section-value">&mdash;</div>
                 @endif
-            @endif
-        </div>
-        <div class="col">
-            <div class="section-label">Venue</div>
-            @if($quotation->venue)
-                <div class="section-value">{{ $quotation->venue->name }}</div>
-                @if($quotation->venue->address)
-                    <div class="section-sub">{{ $quotation->venue->address }}</div>
+            </td>
+            <td style="width:35%">
+                <div class="section-label">Venue</div>
+                @if($quotation->venue)
+                    <div class="section-value">{{ $quotation->venue->name }}</div>
+                    @if($quotation->venue->address)
+                        <div class="section-sub">{{ $quotation->venue->address }}</div>
+                    @endif
+                @else
+                    <div class="section-value">&mdash;</div>
                 @endif
-            @endif
-        </div>
-        <div class="col">
-            <div class="section-label">Valid Until</div>
-            <div class="section-value">{{ $quotation->valid_until?->format('d M Y') ?? '—' }}</div>
-            @if($quotation->valid_until && $quotation->valid_until->isFuture())
-                <div class="section-sub" style="color:#059669">Still valid</div>
-            @else
-                <div class="section-sub" style="color:#dc2626">Expired</div>
-            @endif
-        </div>
-    </div>
+            </td>
+            <td style="width:25%">
+                <div class="section-label">Valid Until</div>
+                <div class="section-value">{{ $quotation->valid_until?->format('d M Y') ?? '—' }}</div>
+                @if($quotation->valid_until && $quotation->valid_until->isFuture())
+                    <div class="section-sub" style="color:#059669">Still valid</div>
+                @elseif($quotation->valid_until)
+                    <div class="section-sub" style="color:#dc2626">Expired</div>
+                @endif
+            </td>
+        </tr>
+    </table>
 
-    <!-- Event Details -->
-    <div class="event-box">
-        <div class="event-box-title">Event Details</div>
-        <div class="event-grid">
-            <div class="event-item">
-                <label>Event Date</label>
-                <span>{{ $quotation->event_date?->format('l, d F Y') ?? '—' }}</span>
-            </div>
-            <div class="event-item">
-                <label>Guest Count</label>
-                <span>{{ $quotation->guest_count ? number_format($quotation->guest_count).' guests' : '—' }}</span>
-            </div>
-            @if($quotation->package)
-                <div class="event-item">
+    {{-- Event details --}}
+    <div class="detail-box">
+        <div class="detail-box-title">Event Details</div>
+        <table class="detail-grid">
+            <tr>
+                <td style="width:34%">
+                    <label>Event Date</label>
+                    <span>{{ $quotation->event_date?->format('l, d F Y') ?? '—' }}</span>
+                </td>
+                <td style="width:33%">
+                    <label>Guest Count</label>
+                    <span>{{ $quotation->guest_count ? number_format($quotation->guest_count).' guests' : '—' }}</span>
+                </td>
+                <td style="width:33%">
                     <label>Package</label>
-                    <span>{{ $quotation->package->name }}</span>
-                </div>
-            @endif
-        </div>
+                    <span>{{ $quotation->package->name ?? '—' }}</span>
+                </td>
+            </tr>
+        </table>
     </div>
 
-    <!-- Items Table -->
-    <table>
+    {{-- Items --}}
+    <table class="items">
         <thead>
             <tr>
-                <th style="width:50%">Description</th>
-                <th>Qty</th>
-                <th>Unit Price</th>
-                <th>Amount</th>
+                <th style="width:52%">Description</th>
+                <th class="num">Qty</th>
+                <th class="num">Unit Price</th>
+                <th class="num">Amount</th>
             </tr>
         </thead>
         <tbody>
@@ -163,68 +97,62 @@
                     <td>
                         {{ $item['name'] ?? $item['description'] ?? '' }}
                         @if(!empty($item['description']) && !empty($item['name']) && $item['description'] !== $item['name'])
-                            <div style="font-size:11px;color:#6b7280;margin-top:2px;">{{ $item['description'] }}</div>
+                            <div class="item-sub">{{ $item['description'] }}</div>
                         @endif
                     </td>
-                    <td>{{ $item['quantity'] ?? 1 }}</td>
-                    <td>
-                        @if(isset($item['unit_price']))
-                            {{ number_format($item['unit_price'], 2) }}
-                        @else
-                            —
-                        @endif
-                    </td>
-                    <td>{{ number_format($item['total'] ?? $item['amount'] ?? (($item['unit_price'] ?? 0) * ($item['quantity'] ?? 1)), 2) }}</td>
+                    <td class="num">{{ $item['quantity'] ?? 1 }}</td>
+                    <td class="num">{{ isset($item['unit_price']) ? number_format($item['unit_price'], 2) : '—' }}</td>
+                    <td class="num">{{ number_format($item['total'] ?? $item['amount'] ?? (($item['unit_price'] ?? 0) * ($item['quantity'] ?? 1)), 2) }}</td>
                 </tr>
             @endforeach
         </tbody>
     </table>
 
-    <!-- Totals -->
+    {{-- Totals --}}
     <div class="totals">
-        <div class="totals-row subtotal">
-            <span class="totals-label">Subtotal</span>
-            <span>{{ number_format($quotation->subtotal, 2) }}</span>
-        </div>
-        @if($quotation->discount_amount > 0)
-            <div class="totals-row discount">
-                <span class="totals-label">Discount</span>
-                <span>- {{ number_format($quotation->discount_amount, 2) }}</span>
-            </div>
-        @endif
-        @if($quotation->tax_amount > 0)
-            <div class="totals-row tax">
-                <span class="totals-label">Tax</span>
-                <span>{{ number_format($quotation->tax_amount, 2) }}</span>
-            </div>
-        @endif
-        <div class="totals-row total">
-            <span>Total</span>
-            <span>{{ number_format($quotation->total_amount, 2) }}</span>
-        </div>
+        <table>
+            <tr class="subtotal">
+                <td class="label">Subtotal</td>
+                <td class="value">{{ number_format($quotation->subtotal, 2) }}</td>
+            </tr>
+            @if($quotation->discount_amount > 0)
+                <tr class="discount">
+                    <td class="label">Discount</td>
+                    <td class="value">- {{ number_format($quotation->discount_amount, 2) }}</td>
+                </tr>
+            @endif
+            @if($quotation->tax_amount > 0)
+                <tr>
+                    <td class="label">Tax</td>
+                    <td class="value">{{ number_format($quotation->tax_amount, 2) }}</td>
+                </tr>
+            @endif
+            <tr class="total">
+                <td class="label">Total</td>
+                <td class="value">{{ number_format($quotation->total_amount, 2) }}</td>
+            </tr>
+        </table>
     </div>
 
-    <!-- Notes -->
-    @if($quotation->notes)
-        <div style="margin-bottom:20px; background:#fffbeb; border-left:3px solid #f59e0b; padding:12px 16px; border-radius:0 6px 6px 0;">
-            <div style="font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.8px;color:#92400e;margin-bottom:4px">Notes</div>
-            <p style="font-size:12px;color:#78350f;">{{ $quotation->notes }}</p>
+    @if($quotation->valid_until)
+        <div class="callout info">
+            This quotation is valid until {{ $quotation->valid_until->format('d F Y') }}. We look forward to making your event memorable.
         </div>
     @endif
 
-    <!-- Terms -->
+    @if($quotation->notes)
+        <div class="callout note">
+            <div class="t">Notes</div>
+            <p>{{ $quotation->notes }}</p>
+        </div>
+    @endif
+
     @if($quotation->terms_and_conditions)
         <div class="terms">
             <h3>Terms &amp; Conditions</h3>
             <p>{{ $quotation->terms_and_conditions }}</p>
         </div>
     @endif
-
-    <!-- Footer -->
-    <div class="footer">
-        This quotation was generated by {{ $branding['business_name'] ?? config('app.name') }} on {{ now()->format('d M Y') }}.
-        For questions, contact us at {{ $branding['contact']['email'] ?? '' }}.
-    </div>
 </div>
 @if(!empty($print))
     <script>window.addEventListener('load', function () { window.print(); });</script>

--- a/resources/views/pdf/receipt.blade.php
+++ b/resources/views/pdf/receipt.blade.php
@@ -2,119 +2,76 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Receipt {{ $payment->payment_number }}</title>
-    <style>
-        * { margin: 0; padding: 0; box-sizing: border-box; }
-        body { font-family: 'DejaVu Sans', Arial, sans-serif; font-size: 13px; color: #1f2937; line-height: 1.5; }
-        .page { padding: 40px; max-width: 800px; margin: 0 auto; }
-
-        .header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 36px; padding-bottom: 24px; border-bottom: 3px solid #4f46e5; }
-        .company-name { font-size: 22px; font-weight: 700; color: #4f46e5; }
-        .company-sub { font-size: 12px; color: #6b7280; margin-top: 2px; }
-        .doc-title { text-align: right; }
-        .doc-title h1 { font-size: 28px; font-weight: 700; color: #111827; letter-spacing: -0.5px; }
-        .doc-title .doc-number { font-size: 14px; color: #4f46e5; font-weight: 600; margin-top: 4px; }
-        .doc-title .doc-date { font-size: 12px; color: #6b7280; }
-
-        .status-badge { display: inline-block; padding: 3px 10px; border-radius: 20px; font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
-        .status-completed { background: #d1fae5; color: #065f46; }
-        .status-pending { background: #fef3c7; color: #92400e; }
-        .status-failed { background: #fee2e2; color: #991b1b; }
-        .status-refunded { background: #e0e7ff; color: #3730a3; }
-
-        .two-col { display: flex; gap: 40px; margin-bottom: 32px; }
-        .col { flex: 1; }
-        .section-label { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; color: #9ca3af; margin-bottom: 6px; }
-        .section-value { font-size: 14px; font-weight: 600; color: #111827; }
-        .section-sub { font-size: 12px; color: #4b5563; margin-top: 2px; }
-
-        .amount-box { background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 8px; padding: 20px 24px; margin-bottom: 28px; text-align: center; }
-        .amount-box .label { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; color: #6b7280; }
-        .amount-box .value { font-size: 32px; font-weight: 700; color: #4f46e5; margin-top: 4px; }
-
-        table { width: 100%; border-collapse: collapse; margin-bottom: 20px; }
-        tbody td { padding: 10px 12px; border-bottom: 1px solid #f3f4f6; font-size: 13px; }
-        tbody td:first-child { color: #6b7280; width: 40%; }
-        tbody td:last-child { text-align: right; font-weight: 600; }
-        tbody tr:last-child td { border-bottom: none; }
-
-        .footer { margin-top: 32px; padding-top: 16px; border-top: 1px solid #e5e7eb; text-align: center; font-size: 11px; color: #9ca3af; }
-    </style>
+    @include('pdf.partials.styles', [
+        'primary' => $branding['colors']['primary'] ?? '#4f46e5',
+        'accent' => $branding['colors']['accent'] ?? '#10b981',
+    ])
 </head>
 <body>
+@include('pdf.partials.footer', ['branding' => $branding, 'note' => 'Receipt '.$payment->payment_number])
 <div class="page">
 
-    <div class="header">
-        <div>
-            <div class="company-name">{{ $branding['business_name'] ?? config('app.name') }}</div>
-            @if(!empty($branding['address']))
-                <div class="company-sub">{{ $branding['address'] }}</div>
-            @endif
-            @if(!empty($branding['phone']))
-                <div class="company-sub">{{ $branding['phone'] }}</div>
-            @endif
-        </div>
-        <div class="doc-title">
-            <h1>RECEIPT</h1>
-            <div class="doc-number">{{ $payment->payment_number }}</div>
-            <div class="doc-date">{{ $payment->payment_date?->format('d M Y') ?? $payment->created_at->format('d M Y') }}</div>
-            <div style="margin-top:6px">
-                <span class="status-badge status-{{ $payment->status }}">{{ ucfirst($payment->status) }}</span>
-            </div>
-        </div>
-    </div>
+    @include('pdf.partials.header', [
+        'branding' => $branding,
+        'docType' => 'RECEIPT',
+        'docNumber' => $payment->payment_number,
+        'docDateLabel' => 'Date',
+        'docDate' => $payment->payment_date?->format('d M Y') ?? $payment->created_at->format('d M Y'),
+        'statusClass' => $payment->status,
+        'statusText' => ucfirst($payment->status),
+    ])
 
-    <div class="two-col">
-        <div class="col">
-            <div class="section-label">Received From</div>
-            @if($payment->client)
-                <div class="section-value">{{ $payment->client->full_name }}</div>
-                <div class="section-sub">{{ $payment->client->email }}</div>
-            @endif
-        </div>
-        <div class="col">
-            <div class="section-label">Booking</div>
-            <div class="section-value">{{ $payment->booking?->booking_number ?? '—' }}</div>
-            @if($payment->booking)
-                <div class="section-sub">Balance: {{ number_format((float) $payment->booking->balance_amount, 2) }} {{ $payment->currency }}</div>
-            @endif
-        </div>
-    </div>
+    <table class="info-table">
+        <tr>
+            <td style="width:50%">
+                <div class="section-label">Received From</div>
+                @if($payment->client)
+                    <div class="section-value">{{ $payment->client->full_name }}</div>
+                    <div class="section-sub">{{ $payment->client->email }}</div>
+                @else
+                    <div class="section-value">&mdash;</div>
+                @endif
+            </td>
+            <td style="width:50%">
+                <div class="section-label">Booking</div>
+                <div class="section-value">{{ $payment->booking?->booking_number ?? '—' }}</div>
+                @if($payment->booking)
+                    <div class="section-sub">Balance: {{ number_format((float) $payment->booking->balance_amount, 2) }} {{ $payment->currency }}</div>
+                @endif
+            </td>
+        </tr>
+    </table>
 
-    <div class="amount-box">
+    <div class="callout amount">
         <div class="label">Amount Paid</div>
         <div class="value">{{ number_format((float) $payment->amount, 2) }} {{ $payment->currency }}</div>
     </div>
 
-    <table>
+    <table class="items">
         <tbody>
-            <tr><td>Payment Number</td><td>{{ $payment->payment_number }}</td></tr>
-            <tr><td>Date</td><td>{{ $payment->payment_date?->format('d M Y') ?? '—' }}</td></tr>
-            <tr><td>Method</td><td>{{ ucwords(str_replace('_', ' ', $payment->payment_method)) }}</td></tr>
+            <tr><td style="width:40%;color:#6b7280">Payment Number</td><td class="num" style="font-weight:600">{{ $payment->payment_number }}</td></tr>
+            <tr><td style="color:#6b7280">Date</td><td class="num" style="font-weight:600">{{ $payment->payment_date?->format('d M Y') ?? '—' }}</td></tr>
+            <tr><td style="color:#6b7280">Method</td><td class="num" style="font-weight:600">{{ ucwords(str_replace('_', ' ', $payment->payment_method)) }}</td></tr>
             @if($payment->installment_name)
-                <tr><td>For</td><td>{{ $payment->installment_name }}</td></tr>
+                <tr><td style="color:#6b7280">For</td><td class="num" style="font-weight:600">{{ $payment->installment_name }}</td></tr>
             @endif
             @if($payment->reference_number)
-                <tr><td>Reference</td><td>{{ $payment->reference_number }}</td></tr>
+                <tr><td style="color:#6b7280">Reference</td><td class="num" style="font-weight:600">{{ $payment->reference_number }}</td></tr>
             @endif
             @if($payment->gateway_payment_id)
-                <tr><td>Gateway Reference</td><td>{{ $payment->gateway_payment_id }}</td></tr>
+                <tr><td style="color:#6b7280">Gateway Reference</td><td class="num" style="font-weight:600">{{ $payment->gateway_payment_id }}</td></tr>
             @endif
-            <tr><td>Status</td><td>{{ ucfirst($payment->status) }}</td></tr>
+            <tr><td style="color:#6b7280">Status</td><td class="num" style="font-weight:600">{{ ucfirst($payment->status) }}</td></tr>
         </tbody>
     </table>
 
     @if($payment->notes)
-        <div style="margin-bottom:20px; background:#fffbeb; border-left:3px solid #f59e0b; padding:12px 16px; border-radius:0 6px 6px 0;">
-            <div style="font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.8px;color:#92400e;margin-bottom:4px">Notes</div>
-            <p style="font-size:12px;color:#78350f;">{{ $payment->notes }}</p>
+        <div class="callout note">
+            <div class="t">Notes</div>
+            <p>{{ $payment->notes }}</p>
         </div>
     @endif
-
-    <div class="footer">
-        This receipt was generated by {{ $branding['business_name'] ?? config('app.name') }} on {{ now()->format('d M Y') }}.
-    </div>
 </div>
 @if(!empty($print))
     <script>window.addEventListener('load', function () { window.print(); });</script>

--- a/resources/views/pdf/reports/_header.blade.php
+++ b/resources/views/pdf/reports/_header.blade.php
@@ -1,0 +1,19 @@
+{{-- Report brand band. Expects: $branding, $docType, $subtitle, $period --}}
+<div class="brand-band">
+    <table>
+        <tr>
+            <td style="width:60%">
+                @if(!empty($branding['logo_pdf']))
+                    <img src="{{ $branding['logo_pdf'] }}" class="brand-logo" alt="">
+                @endif
+                <div class="brand-name">{{ $branding['business_name'] ?? config('app.name') }}</div>
+                <div class="brand-sub">{{ $subtitle }}</div>
+            </td>
+            <td class="doc-meta" style="width:40%">
+                <div class="doc-type">{{ $docType }}</div>
+                <div class="doc-period">{{ $period }}</div>
+                <div class="doc-date">Generated {{ now()->format('d M Y') }}</div>
+            </td>
+        </tr>
+    </table>
+</div>

--- a/resources/views/pdf/reports/_styles.blade.php
+++ b/resources/views/pdf/reports/_styles.blade.php
@@ -1,34 +1,53 @@
+{{-- Shared report stylesheet. dompdf-safe (no flexbox/grid). Brand colours come
+     from BrandingService. Expects: $primary, $accent --}}
+@php
+    $primary = $primary ?? '#4f46e5';
+    $accent  = $accent  ?? '#10b981';
+@endphp
 <style>
+    @page { margin: 0; }
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body { font-family: 'DejaVu Sans', Arial, sans-serif; font-size: 12px; color: #1f2937; line-height: 1.5; }
-    .page { padding: 36px; }
+    .page { padding: 32px 36px 84px; }
 
-    .header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 28px; padding-bottom: 18px; border-bottom: 3px solid #4f46e5; }
-    .company-name { font-size: 20px; font-weight: 700; color: #4f46e5; }
-    .company-sub { font-size: 12px; color: #6b7280; margin-top: 2px; }
-    .doc-title { text-align: right; }
-    .doc-title h1 { font-size: 24px; font-weight: 700; color: #111827; letter-spacing: -0.5px; }
-    .doc-period { font-size: 13px; color: #4f46e5; font-weight: 600; margin-top: 4px; }
-    .doc-date { font-size: 11px; color: #6b7280; }
+    /* Brand band header (table, not flex) */
+    .brand-band { width: 100%; background: {{ $primary }}; border-radius: 10px; color: #fff; margin-bottom: 24px; }
+    .brand-band table { width: 100%; border-collapse: collapse; }
+    .brand-band td { padding: 18px 22px; vertical-align: middle; }
+    .brand-logo { height: 34px; margin-bottom: 6px; }
+    .brand-name { font-size: 19px; font-weight: 700; color: #fff; }
+    .brand-sub { font-size: 11px; color: rgba(255,255,255,0.82); margin-top: 2px; }
+    .doc-meta { text-align: right; }
+    .doc-meta .doc-type { font-size: 23px; font-weight: 700; color: #fff; letter-spacing: 1px; }
+    .doc-meta .doc-period { font-size: 12px; color: #fff; font-weight: 600; margin-top: 4px; }
+    .doc-meta .doc-date { font-size: 10.5px; color: rgba(255,255,255,0.82); margin-top: 2px; }
 
-    .cards { width: 100%; margin-bottom: 26px; }
-    .card { display: inline-block; width: 31%; margin-right: 2%; background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 8px; padding: 12px 14px; vertical-align: top; }
+    /* Stat cards (inline-block is dompdf-safe) */
+    .cards { width: 100%; margin-bottom: 22px; }
+    .card { display: inline-block; width: 31.5%; margin-right: 2%; background: #f9fafb; border: 1px solid #e9ebef; border-top: 3px solid {{ $primary }}; border-radius: 8px; padding: 12px 14px; vertical-align: top; }
     .card:last-child { margin-right: 0; }
-    .card-label { display: block; font-size: 10px; text-transform: uppercase; letter-spacing: 0.6px; color: #9ca3af; }
+    .card-label { display: block; font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.6px; color: #9ca3af; }
     .card-value { display: block; font-size: 18px; font-weight: 700; margin-top: 4px; color: #111827; }
     .card-value.green { color: #059669; }
     .card-value.red { color: #dc2626; }
     .card-value.orange { color: #ea580c; }
-    .card-value.indigo { color: #4f46e5; }
+    .card-value.indigo { color: {{ $primary }}; }
 
-    h2.section { font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.8px; color: #6b7280; margin: 22px 0 10px; }
+    h2.section { font-size: 11.5px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.8px; color: {{ $primary }}; margin: 22px 0 10px; }
 
-    table { width: 100%; border-collapse: collapse; margin-bottom: 16px; }
-    thead th { background: #4f46e5; color: #fff; padding: 8px 10px; text-align: left; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
-    thead th.num { text-align: right; }
-    tbody td { padding: 7px 10px; border-bottom: 1px solid #f3f4f6; font-size: 12px; }
-    tbody td.num { text-align: right; }
-    tbody tr:nth-child(even) { background: #f9fafb; }
+    table.data { width: 100%; border-collapse: collapse; margin-bottom: 16px; }
+    table.data thead { display: table-header-group; }
+    table.data thead th { background: {{ $primary }}; color: #fff; padding: 8px 10px; text-align: left; font-size: 9.5px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.5px; }
+    table.data thead th.num { text-align: right; }
+    table.data tbody tr { page-break-inside: avoid; }
+    table.data tbody td { padding: 7px 10px; border-bottom: 1px solid #eef0f3; font-size: 12px; }
+    table.data tbody td.num { text-align: right; font-variant-numeric: tabular-nums; }
+    table.data tbody tr:nth-child(even) td { background: #f9fafb; }
 
-    .footer { margin-top: 28px; padding-top: 14px; border-top: 1px solid #e5e7eb; text-align: center; font-size: 10px; color: #9ca3af; }
+    .doc-footer {
+        position: fixed; bottom: 0; left: 0; right: 0; height: 58px;
+        padding: 13px 36px 0; border-top: 2px solid {{ $accent }};
+        text-align: center; font-size: 9.5px; color: #9ca3af;
+    }
+    .doc-footer .name { color: {{ $primary }}; font-weight: 700; font-size: 10.5px; }
 </style>

--- a/resources/views/pdf/reports/_styles.blade.php
+++ b/resources/views/pdf/reports/_styles.blade.php
@@ -8,7 +8,7 @@
     @page { margin: 0; }
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body { font-family: 'DejaVu Sans', Arial, sans-serif; font-size: 12px; color: #1f2937; line-height: 1.5; }
-    .page { padding: 32px 36px 84px; }
+    .page { padding: 30px 36px 68px; }
 
     /* Brand band header (table, not flex) */
     .brand-band { width: 100%; background: {{ $primary }}; border-radius: 10px; color: #fff; margin-bottom: 24px; }
@@ -23,7 +23,7 @@
     .doc-meta .doc-date { font-size: 10.5px; color: rgba(255,255,255,0.82); margin-top: 2px; }
 
     /* Stat cards (inline-block is dompdf-safe) */
-    .cards { width: 100%; margin-bottom: 22px; }
+    .cards { width: 100%; margin-bottom: 14px; }
     .card { display: inline-block; width: 31.5%; margin-right: 2%; background: #f9fafb; border: 1px solid #e9ebef; border-top: 3px solid {{ $primary }}; border-radius: 8px; padding: 12px 14px; vertical-align: top; }
     .card:last-child { margin-right: 0; }
     .card-label { display: block; font-size: 9.5px; text-transform: uppercase; letter-spacing: 0.6px; color: #9ca3af; }
@@ -33,7 +33,58 @@
     .card-value.orange { color: #ea580c; }
     .card-value.indigo { color: {{ $primary }}; }
 
-    h2.section { font-size: 11.5px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.8px; color: {{ $primary }}; margin: 22px 0 10px; }
+    h2.section { font-size: 11.5px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.8px; color: {{ $primary }}; margin: 16px 0 9px; }
+    .section-hint { font-size: 9.5px; color: #9ca3af; font-weight: 400; text-transform: none; letter-spacing: 0; }
+
+    /* Insight strip — small KPI chips that fill the row under the cards */
+    .insights { width: 100%; border-collapse: collapse; margin-bottom: 16px; }
+    .insights td { width: 33.33%; padding: 0 8px; vertical-align: top; }
+    .insights td:first-child { padding-left: 0; }
+    .insights td:last-child { padding-right: 0; }
+    .insight { background: #fff; border: 1px solid #e9ebef; border-left: 4px solid {{ $accent }}; border-radius: 8px; padding: 10px 12px; }
+    .insight .i-label { font-size: 9px; text-transform: uppercase; letter-spacing: 0.6px; color: #9ca3af; }
+    .insight .i-value { font-size: 14px; font-weight: 700; color: #111827; margin-top: 2px; }
+    .insight .i-sub { font-size: 9.5px; color: #6b7280; margin-top: 1px; }
+
+    /* Horizontal bar chart (label | track | value) */
+    .chart { width: 100%; border-collapse: collapse; margin-bottom: 12px; }
+    .chart td { padding: 3px 0; vertical-align: middle; border: none; }
+    .chart .c-label { width: 78px; font-size: 10.5px; color: #374151; padding-right: 12px; white-space: nowrap; }
+    .chart .c-value { width: 132px; text-align: right; font-size: 10.5px; font-weight: 600; color: #111827; padding-left: 12px; font-variant-numeric: tabular-nums; }
+    .bar-track { background: #eef0f3; border-radius: 6px; height: 15px; width: 100%; }
+    .bar-fill { background: {{ $primary }}; height: 15px; border-radius: 6px; }
+    .bar-fill.accent { background: {{ $accent }}; }
+    .bar-fill.zero { background: #e5e7eb; }
+
+    /* Segmented (stacked) bar for composition */
+    .seg-track { height: 15px; width: 100%; background: #f1f3f5; border-radius: 6px; }
+    .seg { display: inline-block; height: 15px; vertical-align: top; }
+    /* Status uses a FIXED semantic palette (independent of brand colour) so the
+       four categories stay distinguishable whatever the tenant primary is. */
+    .seg.confirmed { background: #2563eb; }
+    .seg.completed { background: #059669; }
+    .seg.cancelled { background: #ef4444; }
+    .seg.other { background: #cbd5e1; }
+
+    /* Legend */
+    .legend { margin: 0 0 8px; font-size: 9.5px; color: #6b7280; }
+    .legend .dot { display: inline-block; width: 9px; height: 9px; border-radius: 2px; margin: 0 5px 0 14px; vertical-align: middle; }
+    .legend .dot:first-child { margin-left: 0; }
+    .dot.confirmed { background: #2563eb; }
+    .dot.completed { background: #059669; }
+    .dot.cancelled { background: #ef4444; }
+    .dot.other { background: #cbd5e1; }
+
+    /* Occupancy meter rows */
+    .meter { width: 100%; border-collapse: collapse; }
+    .meter td { padding: 5px 0; vertical-align: middle; border-bottom: 1px solid #f1f3f5; }
+    .meter .m-name { font-size: 11px; color: #374151; padding-right: 12px; }
+    .meter .m-bar { width: 46%; }
+    .meter .m-val { width: 70px; text-align: right; font-size: 11px; font-weight: 700; padding-left: 12px; font-variant-numeric: tabular-nums; }
+    .meter .m-days { width: 84px; text-align: right; font-size: 10px; color: #9ca3af; padding-left: 10px; }
+    .bar-fill.high { background: #059669; }
+    .bar-fill.mid { background: #ea580c; }
+    .bar-fill.low { background: #cbd5e1; }
 
     table.data { width: 100%; border-collapse: collapse; margin-bottom: 16px; }
     table.data thead { display: table-header-group; }

--- a/resources/views/pdf/reports/bookings.blade.php
+++ b/resources/views/pdf/reports/bookings.blade.php
@@ -3,26 +3,23 @@
 <head>
     <meta charset="UTF-8">
     <title>Booking Report — {{ $period }}</title>
-    @include('pdf.reports._styles')
+    @include('pdf.reports._styles', [
+        'primary' => $branding['colors']['primary'] ?? '#4f46e5',
+        'accent' => $branding['colors']['accent'] ?? '#10b981',
+    ])
 </head>
 <body>
+<div class="doc-footer">
+    <div class="name">{{ $branding['business_name'] ?? config('app.name') }}</div>
+    <div>Booking Report &middot; {{ $period }} &middot; Generated {{ now()->format('d M Y H:i') }}</div>
+</div>
 <div class="page">
-    <div class="header">
-        <div>
-            <div class="company-name">{{ config('app.name') }}</div>
-            <div class="company-sub">Booking Report</div>
-        </div>
-        <div class="doc-title">
-            <h1>BOOKINGS</h1>
-            <div class="doc-period">{{ $period }}</div>
-            <div class="doc-date">Generated {{ now()->format('d M Y') }}</div>
-        </div>
-    </div>
+    @include('pdf.reports._header', ['branding' => $branding, 'docType' => 'BOOKINGS', 'subtitle' => 'Booking Report', 'period' => $period])
 
     <div class="cards">
         <div class="card">
             <span class="card-label">Total</span>
-            <span class="card-value">{{ $totals['total'] }}</span>
+            <span class="card-value indigo">{{ $totals['total'] }}</span>
         </div>
         <div class="card">
             <span class="card-label">Confirmed</span>
@@ -33,7 +30,7 @@
             <span class="card-value red">{{ $totals['cancelled'] }}</span>
         </div>
     </div>
-    <div class="cards" style="margin-top:-14px">
+    <div class="cards" style="margin-top:10px">
         <div class="card" style="width:100%">
             <span class="card-label">Revenue (excl. cancelled)</span>
             <span class="card-value indigo">{{ number_format($totals['revenue'], 2) }}</span>
@@ -41,7 +38,7 @@
     </div>
 
     <h2 class="section">Monthly Breakdown</h2>
-    <table>
+    <table class="data">
         <thead>
             <tr>
                 <th>Month</th>
@@ -66,7 +63,7 @@
 
     @if(count($byEventType))
         <h2 class="section">By Event Type</h2>
-        <table>
+        <table class="data">
             <thead>
                 <tr><th>Event Type</th><th class="num">Count</th><th class="num">Revenue</th></tr>
             </thead>
@@ -81,8 +78,6 @@
             </tbody>
         </table>
     @endif
-
-    <div class="footer">{{ config('app.name') }} — generated {{ now()->format('d M Y H:i') }}</div>
 </div>
 </body>
 </html>

--- a/resources/views/pdf/reports/bookings.blade.php
+++ b/resources/views/pdf/reports/bookings.blade.php
@@ -16,9 +16,23 @@
 <div class="page">
     @include('pdf.reports._header', ['branding' => $branding, 'docType' => 'BOOKINGS', 'subtitle' => 'Booking Report', 'period' => $period])
 
+    @php
+        $M = collect($months);
+        $maxTotal = max($M->max('total') ?? 0, 1);
+        $busiest = $M->sortByDesc('total')->first();
+        $confRate = ($totals['total'] ?? 0) > 0 ? round(((($totals['confirmed'] ?? 0)) / $totals['total']) * 100) : 0;
+        $cancelRate = ($totals['total'] ?? 0) > 0 ? round((($totals['cancelled'] ?? 0) / $totals['total']) * 100) : 0;
+        $netBookings = max(($totals['total'] ?? 0) - ($totals['cancelled'] ?? 0), 0);
+        $avgValue = $netBookings > 0 ? ($totals['revenue'] ?? 0) / $netBookings : 0;
+        $types = collect($byEventType);
+        $maxType = max($types->max('count') ?? 0, 1);
+        $typeTotal = max($types->sum('count'), 1);
+        $w = fn ($n) => round(($n / $maxTotal) * 100, 1);
+    @endphp
+
     <div class="cards">
         <div class="card">
-            <span class="card-label">Total</span>
+            <span class="card-label">Total Bookings</span>
             <span class="card-value indigo">{{ $totals['total'] }}</span>
         </div>
         <div class="card">
@@ -30,52 +44,73 @@
             <span class="card-value red">{{ $totals['cancelled'] }}</span>
         </div>
     </div>
-    <div class="cards" style="margin-top:10px">
-        <div class="card" style="width:100%">
-            <span class="card-label">Revenue (excl. cancelled)</span>
-            <span class="card-value indigo">{{ number_format($totals['revenue'], 2) }}</span>
-        </div>
-    </div>
 
-    <h2 class="section">Monthly Breakdown</h2>
-    <table class="data">
-        <thead>
-            <tr>
-                <th>Month</th>
-                <th class="num">Total</th>
-                <th class="num">Confirmed</th>
-                <th class="num">Completed</th>
-                <th class="num">Cancelled</th>
-            </tr>
-        </thead>
-        <tbody>
-            @foreach($months as $m)
-                <tr>
-                    <td>{{ $m['label'] }}</td>
-                    <td class="num">{{ $m['total'] }}</td>
-                    <td class="num">{{ $m['confirmed'] }}</td>
-                    <td class="num">{{ $m['completed'] }}</td>
-                    <td class="num">{{ $m['cancelled'] }}</td>
-                </tr>
-            @endforeach
-        </tbody>
+    <table class="insights">
+        <tr>
+            <td>
+                <div class="insight">
+                    <div class="i-label">Confirmation Rate</div>
+                    <div class="i-value">{{ $confRate }}%</div>
+                    <div class="i-sub">{{ $cancelRate }}% cancelled</div>
+                </div>
+            </td>
+            <td>
+                <div class="insight">
+                    <div class="i-label">Busiest Month</div>
+                    <div class="i-value">{{ $busiest['label'] ?? '—' }}</div>
+                    <div class="i-sub">{{ $busiest['total'] ?? 0 }} booking(s)</div>
+                </div>
+            </td>
+            <td>
+                <div class="insight">
+                    <div class="i-label">Avg Booking Value</div>
+                    <div class="i-value">{{ number_format($avgValue, 0) }}</div>
+                    <div class="i-sub">{{ number_format($totals['revenue'], 0) }} over {{ $netBookings }}</div>
+                </div>
+            </td>
+        </tr>
     </table>
 
-    @if(count($byEventType))
-        <h2 class="section">By Event Type</h2>
-        <table class="data">
-            <thead>
-                <tr><th>Event Type</th><th class="num">Count</th><th class="num">Revenue</th></tr>
-            </thead>
-            <tbody>
-                @foreach($byEventType as $t)
-                    <tr>
-                        <td>{{ ucwords(str_replace('_', ' ', $t['type'] ?? '—')) }}</td>
-                        <td class="num">{{ $t['count'] }}</td>
-                        <td class="num">{{ number_format($t['revenue'], 2) }}</td>
-                    </tr>
-                @endforeach
-            </tbody>
+    <h2 class="section">Monthly Bookings <span class="section-hint">— by status</span></h2>
+    <div class="legend">
+        <span class="dot confirmed"></span>Confirmed
+        <span class="dot completed"></span>Completed
+        <span class="dot cancelled"></span>Cancelled
+        <span class="dot other"></span>Other
+    </div>
+    <table class="chart">
+        @foreach($months as $m)
+            @php $other = max($m['total'] - $m['confirmed'] - $m['completed'] - $m['cancelled'], 0); @endphp
+            <tr>
+                <td class="c-label">{{ $m['label'] }}</td>
+                <td>
+                    <div class="seg-track">
+                        @if($m['confirmed'])<div class="seg confirmed" style="width: {{ $w($m['confirmed']) }}%;"></div>@endif
+                        @if($m['completed'])<div class="seg completed" style="width: {{ $w($m['completed']) }}%;"></div>@endif
+                        @if($m['cancelled'])<div class="seg cancelled" style="width: {{ $w($m['cancelled']) }}%;"></div>@endif
+                        @if($other)<div class="seg other" style="width: {{ $w($other) }}%;"></div>@endif
+                    </div>
+                </td>
+                <td class="c-value">{{ $m['total'] }}</td>
+            </tr>
+        @endforeach
+    </table>
+
+    @if($types->count())
+        <h2 class="section">By Event Type <span class="section-hint">— share of bookings</span></h2>
+        <table class="chart">
+            @foreach($types->sortByDesc('count') as $t)
+                @php $pct = round(($t['count'] / $maxType) * 100); $share = round(($t['count'] / $typeTotal) * 100); @endphp
+                <tr>
+                    <td class="c-label">{{ ucwords(str_replace('_', ' ', $t['type'] ?? '—')) }}</td>
+                    <td>
+                        <div class="bar-track">
+                            <div class="bar-fill" style="width: {{ max($pct, 2) }}%;"></div>
+                        </div>
+                    </td>
+                    <td class="c-value">{{ $t['count'] }} <span style="color:#9ca3af;font-weight:400">({{ $share }}%)</span></td>
+                </tr>
+            @endforeach
         </table>
     @endif
 </div>

--- a/resources/views/pdf/reports/occupancy.blade.php
+++ b/resources/views/pdf/reports/occupancy.blade.php
@@ -3,24 +3,21 @@
 <head>
     <meta charset="UTF-8">
     <title>Occupancy Report — {{ $period }}</title>
-    @include('pdf.reports._styles')
+    @include('pdf.reports._styles', [
+        'primary' => $branding['colors']['primary'] ?? '#4f46e5',
+        'accent' => $branding['colors']['accent'] ?? '#10b981',
+    ])
 </head>
 <body>
+<div class="doc-footer">
+    <div class="name">{{ $branding['business_name'] ?? config('app.name') }}</div>
+    <div>Occupancy Report &middot; {{ $period }} &middot; Generated {{ now()->format('d M Y H:i') }}</div>
+</div>
 <div class="page">
-    <div class="header">
-        <div>
-            <div class="company-name">{{ config('app.name') }}</div>
-            <div class="company-sub">Occupancy Report</div>
-        </div>
-        <div class="doc-title">
-            <h1>OCCUPANCY</h1>
-            <div class="doc-period">{{ $period }}</div>
-            <div class="doc-date">Generated {{ now()->format('d M Y') }}</div>
-        </div>
-    </div>
+    @include('pdf.reports._header', ['branding' => $branding, 'docType' => 'OCCUPANCY', 'subtitle' => 'Occupancy Report', 'period' => $period])
 
     <h2 class="section">Venue Utilization</h2>
-    <table>
+    <table class="data">
         <thead>
             <tr><th>Venue</th><th class="num">Booked Days</th><th class="num">Occupancy %</th></tr>
         </thead>
@@ -36,8 +33,6 @@
             @endforelse
         </tbody>
     </table>
-
-    <div class="footer">{{ config('app.name') }} — generated {{ now()->format('d M Y H:i') }}</div>
 </div>
 </body>
 </html>

--- a/resources/views/pdf/reports/occupancy.blade.php
+++ b/resources/views/pdf/reports/occupancy.blade.php
@@ -16,23 +16,67 @@
 <div class="page">
     @include('pdf.reports._header', ['branding' => $branding, 'docType' => 'OCCUPANCY', 'subtitle' => 'Occupancy Report', 'period' => $period])
 
-    <h2 class="section">Venue Utilization</h2>
-    <table class="data">
-        <thead>
-            <tr><th>Venue</th><th class="num">Booked Days</th><th class="num">Occupancy %</th></tr>
-        </thead>
-        <tbody>
-            @forelse($venueOccupancy as $v)
+    @php
+        $V = collect($venueOccupancy)->sortByDesc('occupancy_pct')->values();
+        $maxPct = max($V->max('occupancy_pct') ?? 0, 0.0001);
+        $avgPct = $V->count() ? $V->avg('occupancy_pct') : 0;
+        $totalDays = $V->sum('booked_days');
+        $top = $V->first();
+        $active = $V->filter(fn ($v) => ($v['booked_days'] ?? 0) > 0)->count();
+    @endphp
+
+    @if($V->count())
+        <table class="insights">
+            <tr>
+                <td>
+                    <div class="insight">
+                        <div class="i-label">Top Venue</div>
+                        <div class="i-value" style="font-size:12px">{{ $top['venue'] ?? '—' }}</div>
+                        <div class="i-sub">{{ rtrim(rtrim(number_format($top['occupancy_pct'] ?? 0, 1), '0'), '.') }}% occupied</div>
+                    </div>
+                </td>
+                <td>
+                    <div class="insight">
+                        <div class="i-label">Avg Occupancy</div>
+                        <div class="i-value">{{ rtrim(rtrim(number_format($avgPct, 1), '0'), '.') }}%</div>
+                        <div class="i-sub">{{ $active }} of {{ $V->count() }} venues booked</div>
+                    </div>
+                </td>
+                <td>
+                    <div class="insight">
+                        <div class="i-label">Total Booked Days</div>
+                        <div class="i-value">{{ number_format($totalDays) }}</div>
+                        <div class="i-sub">across all venues</div>
+                    </div>
+                </td>
+            </tr>
+        </table>
+    @endif
+
+    <h2 class="section">Venue Utilization <span class="section-hint">— ranked by occupancy</span></h2>
+    @if($V->count())
+        <table class="meter">
+            @foreach($V as $v)
+                @php
+                    $rel = round((($v['occupancy_pct'] ?? 0) / $maxPct) * 100);
+                    $tier = $rel >= 66 ? 'high' : ($rel >= 33 ? 'mid' : 'low');
+                    $shown = ($v['booked_days'] ?? 0) > 0 ? max($rel, 3) : 0;
+                @endphp
                 <tr>
-                    <td>{{ $v['venue'] }}</td>
-                    <td class="num">{{ $v['booked_days'] }}</td>
-                    <td class="num">{{ $v['occupancy_pct'] }}%</td>
+                    <td class="m-name">{{ $v['venue'] }}</td>
+                    <td class="m-bar">
+                        <div class="bar-track">
+                            <div class="bar-fill {{ $tier }}" style="width: {{ $shown }}%;"></div>
+                        </div>
+                    </td>
+                    <td class="m-val">{{ rtrim(rtrim(number_format($v['occupancy_pct'] ?? 0, 1), '0'), '.') }}%</td>
+                    <td class="m-days">{{ $v['booked_days'] }} day(s)</td>
                 </tr>
-            @empty
-                <tr><td colspan="3" style="text-align:center;color:#9ca3af">No venue data for this period.</td></tr>
-            @endforelse
-        </tbody>
-    </table>
+            @endforeach
+        </table>
+    @else
+        <p style="text-align:center;color:#9ca3af;padding:24px 0">No venue data for this period.</p>
+    @endif
 </div>
 </body>
 </html>

--- a/resources/views/pdf/reports/revenue.blade.php
+++ b/resources/views/pdf/reports/revenue.blade.php
@@ -16,6 +16,19 @@
 <div class="page">
     @include('pdf.reports._header', ['branding' => $branding, 'docType' => 'REVENUE', 'subtitle' => 'Revenue Report', 'period' => $period])
 
+    @php
+        $M = collect($months);
+        $maxRev = max($M->max('revenue') ?? 0, 1);
+        $activeMonths = $M->filter(fn ($m) => $m['revenue'] > 0);
+        $peak = $M->sortByDesc('revenue')->first();
+        $avgActive = $activeMonths->count() ? $activeMonths->avg('revenue') : 0;
+        $billed = ($totals['collected'] ?? 0) + ($totals['outstanding'] ?? 0);
+        $collectionRate = $billed > 0 ? round(($totals['collected'] / $billed) * 100) : 0;
+        $methods = collect($byMethod);
+        $maxMethod = max($methods->max('total') ?? 0, 1);
+        $methodTotal = max($methods->sum('total'), 1);
+    @endphp
+
     <div class="cards">
         <div class="card">
             <span class="card-label">Collected</span>
@@ -31,37 +44,63 @@
         </div>
     </div>
 
-    <h2 class="section">Monthly Breakdown</h2>
-    <table class="data">
-        <thead>
-            <tr><th>Month</th><th class="num">Revenue</th><th class="num">Payments</th></tr>
-        </thead>
-        <tbody>
-            @foreach($months as $m)
-                <tr>
-                    <td>{{ $m['label'] }}</td>
-                    <td class="num">{{ number_format($m['revenue'], 2) }}</td>
-                    <td class="num">{{ $m['count'] }}</td>
-                </tr>
-            @endforeach
-        </tbody>
+    <table class="insights">
+        <tr>
+            <td>
+                <div class="insight">
+                    <div class="i-label">Collection Rate</div>
+                    <div class="i-value">{{ $collectionRate }}%</div>
+                    <div class="i-sub">of {{ number_format($billed, 0) }} billed collected</div>
+                </div>
+            </td>
+            <td>
+                <div class="insight">
+                    <div class="i-label">Peak Month</div>
+                    <div class="i-value">{{ $peak['label'] ?? '—' }}</div>
+                    <div class="i-sub">{{ number_format($peak['revenue'] ?? 0, 0) }} collected</div>
+                </div>
+            </td>
+            <td>
+                <div class="insight">
+                    <div class="i-label">Avg / Active Month</div>
+                    <div class="i-value">{{ number_format($avgActive, 0) }}</div>
+                    <div class="i-sub">{{ $activeMonths->count() }} month(s) with revenue</div>
+                </div>
+            </td>
+        </tr>
     </table>
 
-    @if(count($byMethod))
-        <h2 class="section">By Payment Method</h2>
-        <table class="data">
-            <thead>
-                <tr><th>Method</th><th class="num">Total</th><th class="num">Transactions</th></tr>
-            </thead>
-            <tbody>
-                @foreach($byMethod as $m)
-                    <tr>
-                        <td>{{ ucwords(str_replace('_', ' ', $m['method'] ?? '—')) }}</td>
-                        <td class="num">{{ number_format($m['total'], 2) }}</td>
-                        <td class="num">{{ $m['count'] }}</td>
-                    </tr>
-                @endforeach
-            </tbody>
+    <h2 class="section">Monthly Revenue <span class="section-hint">— collected payments</span></h2>
+    <table class="chart">
+        @foreach($months as $m)
+            @php $pct = round(($m['revenue'] / $maxRev) * 100); @endphp
+            <tr>
+                <td class="c-label">{{ $m['label'] }}</td>
+                <td>
+                    <div class="bar-track">
+                        <div class="bar-fill {{ $m['revenue'] > 0 ? '' : 'zero' }}" style="width: {{ max($pct, $m['revenue'] > 0 ? 2 : 0) }}%;"></div>
+                    </div>
+                </td>
+                <td class="c-value">{{ number_format($m['revenue'], 0) }} <span style="color:#9ca3af;font-weight:400">({{ $m['count'] }})</span></td>
+            </tr>
+        @endforeach
+    </table>
+
+    @if($methods->count())
+        <h2 class="section">By Payment Method <span class="section-hint">— share of collected</span></h2>
+        <table class="chart">
+            @foreach($methods->sortByDesc('total') as $m)
+                @php $pct = round(($m['total'] / $maxMethod) * 100); $share = round(($m['total'] / $methodTotal) * 100); @endphp
+                <tr>
+                    <td class="c-label">{{ ucwords(str_replace('_', ' ', $m['method'] ?? '—')) }}</td>
+                    <td>
+                        <div class="bar-track">
+                            <div class="bar-fill accent" style="width: {{ max($pct, 2) }}%;"></div>
+                        </div>
+                    </td>
+                    <td class="c-value">{{ number_format($m['total'], 0) }} <span style="color:#9ca3af;font-weight:400">({{ $share }}%)</span></td>
+                </tr>
+            @endforeach
         </table>
     @endif
 </div>

--- a/resources/views/pdf/reports/revenue.blade.php
+++ b/resources/views/pdf/reports/revenue.blade.php
@@ -3,21 +3,18 @@
 <head>
     <meta charset="UTF-8">
     <title>Revenue Report — {{ $period }}</title>
-    @include('pdf.reports._styles')
+    @include('pdf.reports._styles', [
+        'primary' => $branding['colors']['primary'] ?? '#4f46e5',
+        'accent' => $branding['colors']['accent'] ?? '#10b981',
+    ])
 </head>
 <body>
+<div class="doc-footer">
+    <div class="name">{{ $branding['business_name'] ?? config('app.name') }}</div>
+    <div>Revenue Report &middot; {{ $period }} &middot; Generated {{ now()->format('d M Y H:i') }}</div>
+</div>
 <div class="page">
-    <div class="header">
-        <div>
-            <div class="company-name">{{ config('app.name') }}</div>
-            <div class="company-sub">Revenue Report</div>
-        </div>
-        <div class="doc-title">
-            <h1>REVENUE</h1>
-            <div class="doc-period">{{ $period }}</div>
-            <div class="doc-date">Generated {{ now()->format('d M Y') }}</div>
-        </div>
-    </div>
+    @include('pdf.reports._header', ['branding' => $branding, 'docType' => 'REVENUE', 'subtitle' => 'Revenue Report', 'period' => $period])
 
     <div class="cards">
         <div class="card">
@@ -35,7 +32,7 @@
     </div>
 
     <h2 class="section">Monthly Breakdown</h2>
-    <table>
+    <table class="data">
         <thead>
             <tr><th>Month</th><th class="num">Revenue</th><th class="num">Payments</th></tr>
         </thead>
@@ -52,7 +49,7 @@
 
     @if(count($byMethod))
         <h2 class="section">By Payment Method</h2>
-        <table>
+        <table class="data">
             <thead>
                 <tr><th>Method</th><th class="num">Total</th><th class="num">Transactions</th></tr>
             </thead>
@@ -67,8 +64,6 @@
             </tbody>
         </table>
     @endif
-
-    <div class="footer">{{ config('app.name') }} — generated {{ now()->format('d M Y H:i') }}</div>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## What
Rebuilds every downloadable PDF — **Quotation, Inquiry, Receipt** and the **Revenue / Bookings / Occupancy reports** — to render correctly under dompdf and read as polished, print-ready customer handouts that fit A4.

## Why
- The templates used `display:flex` for the header, info columns and totals. **dompdf has no flexbox support**, so those rows collapsed/misaligned in the actual PDF.
- Brand colour + logo were never used — hardcoded indigo, and **reports got no branding at all**.
- `$branding['address']`/`['phone']` were read from the wrong keys (they live under `contact`), so company contact lines never appeared.

## Changes
- **dompdf-safe layout:** every multi-column block converted from flex → tables / inline-block. Explicit A4 `@page`, repeating table headers (`thead { table-header-group }`), `page-break-inside: avoid` rows → clean multi-page pagination.
- **Shared system:** new partials `pdf/partials/{styles,header,footer}` + `pdf/reports/_header` so the six docs share one brand-coloured design. Vertical rhythm tightened so a typical quotation fits a single page.
- **Tenant branding:** accent colours pulled from `BrandingService` primary/accent (already sanitised). New `getLogoDataUri()` embeds an uploaded tenant logo as a base64 data URI (no remote fetch, offline-safe), falling back to a styled wordmark.
- Report PDFs now receive branding and set A4 paper explicitly.

## Verification
- Rendered all six PDFs from seeded data and rasterised every page to images — header bands, aligned columns, branded tables, right-aligned totals, per-page accent footer all correct; quotation fits one A4 page.
- `php artisan test` (print / report / payment / inquiry suites): **37 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)